### PR TITLE
One okapi token to rule them all!

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -34,5 +34,9 @@ RSpec/DescribeClass:
 RSpec/MultipleMemoizedHelpers:
   Enabled: false
 
+Style/ClassVars:
+  Exclude:
+  - 'tasks/helpers/folio_request.rb'
+
 Style/SlicingWithRange:
   Enabled: false

--- a/tasks/acquisitions/delete_acq_units.rake
+++ b/tasks/acquisitions/delete_acq_units.rake
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require_relative '../../lib/folio_request'
 require_relative '../helpers/acq_units'
 require 'csv'
 

--- a/tasks/acquisitions/delete_finance_settings.rake
+++ b/tasks/acquisitions/delete_finance_settings.rake
@@ -2,7 +2,6 @@
 
 require 'csv'
 require 'require_all'
-require_relative '../../lib/folio_request'
 require_rel '../helpers/finance'
 
 namespace :acquisitions do

--- a/tasks/acquisitions/delete_organizations.rake
+++ b/tasks/acquisitions/delete_organizations.rake
@@ -2,7 +2,6 @@
 
 require 'csv'
 require 'require_all'
-require_relative '../../lib/folio_request'
 require_relative '../helpers/acq_units'
 require_rel '../helpers/organizations'
 

--- a/tasks/acquisitions/load_acq_units.rake
+++ b/tasks/acquisitions/load_acq_units.rake
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'csv'
-require_relative '../../lib/folio_request'
 require_relative '../helpers/acq_units'
 
 namespace :acquisitions do

--- a/tasks/acquisitions/load_finance_settings.rake
+++ b/tasks/acquisitions/load_finance_settings.rake
@@ -2,7 +2,6 @@
 
 require 'csv'
 require 'require_all'
-require_relative '../../lib/folio_request'
 require_relative '../helpers/acq_units'
 require_rel '../helpers/finance'
 

--- a/tasks/acquisitions/load_organizations.rake
+++ b/tasks/acquisitions/load_organizations.rake
@@ -3,7 +3,6 @@
 require 'csv'
 require 'nokogiri'
 require 'require_all'
-require_relative '../../lib/folio_request'
 require_relative '../helpers/acq_units'
 require_rel '../helpers/organizations'
 

--- a/tasks/acquisitions/update_finance_settings.rake
+++ b/tasks/acquisitions/update_finance_settings.rake
@@ -2,7 +2,6 @@
 
 require 'csv'
 require 'require_all'
-require_relative '../../lib/folio_request'
 require_rel '../helpers/finance'
 
 namespace :acquisitions do

--- a/tasks/acquisitions/update_organizations.rake
+++ b/tasks/acquisitions/update_organizations.rake
@@ -2,7 +2,6 @@
 
 require 'csv'
 require 'require_all'
-require_relative '../../lib/folio_request'
 require_relative '../helpers/acq_units'
 require_rel '../helpers/organizations'
 

--- a/tasks/data_import/load_import_profiles.rake
+++ b/tasks/data_import/load_import_profiles.rake
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require_relative '../../lib/folio_request'
 require_relative '../helpers/data_import'
 
 namespace :data_import do

--- a/tasks/helpers/acq_units.rb
+++ b/tasks/helpers/acq_units.rb
@@ -5,7 +5,7 @@ require_relative '../helpers/folio_request'
 # Module to encapsulate methods used by acq_unit rake tasks
 module AcquisitionsUnitsTaskHelpers
   include FolioRequestHelper
-  
+
   # acquisitions units
   def acq_units_csv
     CSV.parse(File.open("#{Settings.tsv}/acquisitions/acquisitions-units.tsv"), headers: true,

--- a/tasks/helpers/acq_units.rb
+++ b/tasks/helpers/acq_units.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
+require_relative '../helpers/folio_request'
+
 # Module to encapsulate methods used by acq_unit rake tasks
 module AcquisitionsUnitsTaskHelpers
+  include FolioRequestHelper
+  
   # acquisitions units
   def acq_units_csv
     CSV.parse(File.open("#{Settings.tsv}/acquisitions/acquisitions-units.tsv"), headers: true,
@@ -9,7 +13,7 @@ module AcquisitionsUnitsTaskHelpers
   end
 
   def acq_unit_id(name)
-    response = FolioRequest.new.get_cql('/acquisitions-units-storage/units', "name==#{name}")['acquisitionsUnits']
+    response = @@folio_request.get_cql('/acquisitions-units-storage/units', "name==#{name}")['acquisitionsUnits']
     begin
       response[0]['id']
     rescue NoMethodError
@@ -27,10 +31,10 @@ module AcquisitionsUnitsTaskHelpers
   end
 
   def acq_units_delete(id)
-    FolioRequest.new.delete("/acquisitions-units-storage/units/#{id}")
+    @@folio_request.delete("/acquisitions-units-storage/units/#{id}")
   end
 
   def acq_units_post(obj)
-    FolioRequest.new.post('/acquisitions-units-storage/units', obj.to_json)
+    @@folio_request.post('/acquisitions-units-storage/units', obj.to_json)
   end
 end

--- a/tasks/helpers/data_import.rb
+++ b/tasks/helpers/data_import.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
+require_relative '../helpers/folio_request'
+
 # Module to encapsulate methods used by import_profiles rake tasks
 module DataImportTaskHelpers
+  include FolioRequestHelper
+
   def job_profiles_json
     profile = JSON.parse(File.read("#{Settings.json}/data-import-profiles/jobProfiles.json"))
     profile.delete('totalRecords')
@@ -9,11 +13,11 @@ module DataImportTaskHelpers
   end
 
   def job_profiles_post(obj)
-    FolioRequest.new.post('/data-import-profiles/jobProfiles', obj.to_json)
+    @@folio_request.post('/data-import-profiles/jobProfiles', obj.to_json)
   end
 
   def job_profiles_get(name)
-    response = FolioRequest.new.get_cql('/data-import-profiles/jobProfiles', "name==#{name}")['jobProfiles']
+    response = @@folio_request.get_cql('/data-import-profiles/jobProfiles', "name==#{name}")['jobProfiles']
     begin
       response[0]['id']
     rescue NoMethodError
@@ -28,11 +32,11 @@ module DataImportTaskHelpers
   end
 
   def action_profiles_post(obj)
-    FolioRequest.new.post('/data-import-profiles/actionProfiles', obj.to_json)
+    @@folio_request.post('/data-import-profiles/actionProfiles', obj.to_json)
   end
 
   def action_profiles_get(name)
-    response = FolioRequest.new.get_cql('/data-import-profiles/actionProfiles', "name==#{name}")['actionProfiles']
+    response = @@folio_request.get_cql('/data-import-profiles/actionProfiles', "name==#{name}")['actionProfiles']
     begin
       response[0]['id']
     rescue NoMethodError
@@ -47,11 +51,11 @@ module DataImportTaskHelpers
   end
 
   def mapping_profiles_post(obj)
-    FolioRequest.new.post('/data-import-profiles/mappingProfiles', obj.to_json)
+    @@folio_request.post('/data-import-profiles/mappingProfiles', obj.to_json)
   end
 
   def mapping_profiles_get(name)
-    response = FolioRequest.new.get_cql('/data-import-profiles/mappingProfiles', "name==#{name}")['mappingProfiles']
+    response = @@folio_request.get_cql('/data-import-profiles/mappingProfiles', "name==#{name}")['mappingProfiles']
     begin
       response[0]['id']
     rescue NoMethodError
@@ -85,7 +89,7 @@ module DataImportTaskHelpers
   end
 
   def profile_associations_post(payload, master, detail)
-    FolioRequest.new.post("/data-import-profiles/profileAssociations?master=#{master}&detail=#{detail}",
-                          payload.to_json)
+    @@folio_request.post("/data-import-profiles/profileAssociations?master=#{master}&detail=#{detail}",
+                         payload.to_json)
   end
 end

--- a/tasks/helpers/finance/budgets.rb
+++ b/tasks/helpers/finance/budgets.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
+require_relative '../folio_request'
+
 # Module to encapsulate budget methods used by finance_settings rake tasks
 module BudgetHelpers
+  include FolioRequestHelper
+
   def budgets_csv
     CSV.parse(File.open("#{Settings.tsv}/acquisitions/budgets.tsv"), headers: true, col_sep: "\t").map(&:to_h)
   end
@@ -25,8 +29,8 @@ module BudgetHelpers
   end
 
   def budget_id(fund_id, fy_id)
-    response = FolioRequest.new.get_cql('/finance/budgets',
-                                        "fundId==#{fund_id}&fiscalYearId=#{fy_id}")['budgets']
+    response = @@folio_request.get_cql('/finance/budgets',
+                                       "fundId==#{fund_id}&fiscalYearId=#{fy_id}")['budgets']
     begin
       response[0]['id']
     rescue NoMethodError
@@ -35,14 +39,14 @@ module BudgetHelpers
   end
 
   def budgets_delete(id)
-    FolioRequest.new.delete("/finance/budgets/#{id}")
+    @@folio_request.delete("/finance/budgets/#{id}")
   end
 
   def budgets_post(obj)
-    FolioRequest.new.post('/finance/budgets', obj.to_json)
+    @@folio_request.post('/finance/budgets', obj.to_json)
   end
 
   def budgets_put(id, obj)
-    FolioRequest.new.put("/finance/budgets/#{id}", obj.to_json)
+    @@folio_request.put("/finance/budgets/#{id}", obj.to_json)
   end
 end

--- a/tasks/helpers/finance/expense_classes.rb
+++ b/tasks/helpers/finance/expense_classes.rb
@@ -1,13 +1,17 @@
 # frozen_string_literal: true
 
+require_relative '../folio_request'
+
 # Module to encapsulate expense class methods used by finance_settings rake tasks
 module ExpenseClassHelpers
+  include FolioRequestHelper
+
   def expense_classes_csv
     CSV.parse(File.open("#{Settings.tsv}/acquisitions/expense-classes.tsv"), headers: true, col_sep: "\t").map(&:to_h)
   end
 
   def expense_class_id(code)
-    response = FolioRequest.new.get_cql('/finance/expense-classes', "code==#{code}")['expenseClasses']
+    response = @@folio_request.get_cql('/finance/expense-classes', "code==#{code}")['expenseClasses']
     begin
       response[0]['id']
     rescue NoMethodError
@@ -25,10 +29,10 @@ module ExpenseClassHelpers
   end
 
   def expense_class_delete(id)
-    FolioRequest.new.delete("/finance/expense-classes/#{id}")
+    @@folio_request.delete("/finance/expense-classes/#{id}")
   end
 
   def expense_classes_post(obj)
-    FolioRequest.new.post('/finance/expense-classes', obj.to_json)
+    @@folio_request.post('/finance/expense-classes', obj.to_json)
   end
 end

--- a/tasks/helpers/finance/finance_groups.rb
+++ b/tasks/helpers/finance/finance_groups.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
+require_relative '../folio_request'
+
 # Module to encapsulate finance group methods used by finance_settings rake tasks
 module FinanceGroupHelpers
+  include FolioRequestHelper
+
   def finance_groups_csv
     CSV.parse(File.open("#{Settings.tsv}/acquisitions/finance-groups.tsv"), headers: true, col_sep: "\t").map(&:to_h)
   end
@@ -15,7 +19,7 @@ module FinanceGroupHelpers
   end
 
   def finance_group_id(code)
-    response = FolioRequest.new.get_cql('/finance/groups', "code==#{code}")['groups']
+    response = @@folio_request.get_cql('/finance/groups', "code==#{code}")['groups']
     begin
       response[0]['id']
     rescue NoMethodError
@@ -24,10 +28,10 @@ module FinanceGroupHelpers
   end
 
   def finance_groups_delete(id)
-    FolioRequest.new.delete("/finance/groups/#{id}")
+    @@folio_request.delete("/finance/groups/#{id}")
   end
 
   def finance_groups_post(obj)
-    FolioRequest.new.post('/finance/groups', obj.to_json)
+    @@folio_request.post('/finance/groups', obj.to_json)
   end
 end

--- a/tasks/helpers/finance/fiscal_years.rb
+++ b/tasks/helpers/finance/fiscal_years.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 
+require_relative '../folio_request'
+
 # Module to encapsulate fiscal year methods used by finance_settings rake tasks
 module FiscalYearHelpers
+  include FolioRequestHelper
   def fiscal_years_csv
     CSV.parse(File.open("#{Settings.tsv}/acquisitions/fiscal-years.tsv"), headers: true, col_sep: "\t").map(&:to_h)
   end
@@ -15,7 +18,7 @@ module FiscalYearHelpers
   end
 
   def fiscal_year_id(code)
-    response = FolioRequest.new.get_cql('/finance/fiscal-years', "code==#{code}")['fiscalYears']
+    response = @@folio_request.get_cql('/finance/fiscal-years', "code==#{code}")['fiscalYears']
     begin
       response[0]['id']
     rescue NoMethodError
@@ -24,10 +27,10 @@ module FiscalYearHelpers
   end
 
   def fiscal_years_delete(id)
-    FolioRequest.new.delete("/finance/fiscal-years/#{id}")
+    @@folio_request.delete("/finance/fiscal-years/#{id}")
   end
 
   def fiscal_years_post(obj)
-    FolioRequest.new.post('/finance/fiscal-years', obj.to_json)
+    @@folio_request.post('/finance/fiscal-years', obj.to_json)
   end
 end

--- a/tasks/helpers/finance/fund_types.rb
+++ b/tasks/helpers/finance/fund_types.rb
@@ -1,13 +1,17 @@
 # frozen_string_literal: true
 
+require_relative '../folio_request'
+
 # Module to encapsulate fund_type methods used by finance_settings rake tasks
 module FundTypeHelpers
+  include FolioRequestHelper
+
   def fund_types_csv
     CSV.parse(File.open("#{Settings.tsv}/acquisitions/fund-types.tsv"), headers: true, col_sep: "\t").map(&:to_h)
   end
 
   def fund_type_id(name)
-    response = FolioRequest.new.get_cql('/finance/fund-types', "name==#{name}")['fundTypes']
+    response = @@folio_request.get_cql('/finance/fund-types', "name==#{name}")['fundTypes']
     begin
       response[0]['id']
     rescue NoMethodError
@@ -16,10 +20,10 @@ module FundTypeHelpers
   end
 
   def fund_types_delete(id)
-    FolioRequest.new.delete("/finance/fund-types/#{id}")
+    @@folio_request.delete("/finance/fund-types/#{id}")
   end
 
   def fund_types_post(obj)
-    FolioRequest.new.post('/finance/fund-types', obj.to_json)
+    @@folio_request.post('/finance/fund-types', obj.to_json)
   end
 end

--- a/tasks/helpers/finance/funds.rb
+++ b/tasks/helpers/finance/funds.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
+require_relative '../folio_request'
+
 # Module to encapsulate fund methods used by finance_settings rake tasks
 module FundHelpers
+  include FolioRequestHelper
+
   def funds_csv
     CSV.parse(File.open("#{Settings.tsv}/acquisitions/funds.tsv"), headers: true, col_sep: "\t").map(&:to_h)
   end
@@ -24,7 +28,7 @@ module FundHelpers
   end
 
   def fund_id(code)
-    response = FolioRequest.new.get_cql('/finance/funds', "code==#{code}")['funds']
+    response = @@folio_request.get_cql('/finance/funds', "code==#{code}")['funds']
     begin
       response[0]['id']
     rescue NoMethodError
@@ -33,10 +37,10 @@ module FundHelpers
   end
 
   def funds_delete(id)
-    FolioRequest.new.delete("/finance/funds/#{id}")
+    @@folio_request.delete("/finance/funds/#{id}")
   end
 
   def funds_post(obj)
-    FolioRequest.new.post('/finance/funds', obj.to_json)
+    @@folio_request.post('/finance/funds', obj.to_json)
   end
 end

--- a/tasks/helpers/finance/ledgers.rb
+++ b/tasks/helpers/finance/ledgers.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
+require_relative '../folio_request'
+
 # Module to encapsulate methods used by finance_settings rake tasks
 module LedgerHelpers
+  include FolioRequestHelper
+
   def ledgers_csv
     CSV.parse(File.open("#{Settings.tsv}/acquisitions/ledgers.tsv"), headers: true, col_sep: "\t").map(&:to_h)
   end
@@ -19,7 +23,7 @@ module LedgerHelpers
   end
 
   def ledger_id(code)
-    response = FolioRequest.new.get_cql('/finance/ledgers', "code==#{code}")['ledgers']
+    response = @@folio_request.get_cql('/finance/ledgers', "code==#{code}")['ledgers']
     begin
       response[0]['id']
     rescue NoMethodError
@@ -28,10 +32,10 @@ module LedgerHelpers
   end
 
   def ledgers_delete(id)
-    FolioRequest.new.delete("/finance/ledgers/#{id}")
+    @@folio_request.delete("/finance/ledgers/#{id}")
   end
 
   def ledgers_post(obj)
-    FolioRequest.new.post('/finance/ledgers', obj.to_json)
+    @@folio_request.post('/finance/ledgers', obj.to_json)
   end
 end

--- a/tasks/helpers/folio_request.rb
+++ b/tasks/helpers/folio_request.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require_relative '../../lib/folio_request'
+
+# Module to encapsulate folio request method
+module FolioRequestHelper
+  @@folio_request = FolioRequest.new
+end

--- a/tasks/helpers/inventory.rb
+++ b/tasks/helpers/inventory.rb
@@ -1,12 +1,16 @@
 # frozen_string_literal: true
 
-# Module to encapsulate methods used by inventory settings rake tasks
+require_relative '../helpers/folio_request'
+
+# Module to encapsulate methods used by inventory settings rake task
 module InventoryTaskHelpers
+  include FolioRequestHelper
+
   def item_note_types_csv
     CSV.parse(File.open("#{Settings.tsv}/inventory/item-note-types.tsv"), headers: true, col_sep: "\t").map(&:to_h)
   end
 
   def item_note_types_post(obj)
-    folio_request.post('/item-note-types', obj.to_json)
+    @@folio_request.post('/item-note-types', obj.to_json)
   end
 end

--- a/tasks/helpers/organizations/org_categories.rb
+++ b/tasks/helpers/organizations/org_categories.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
+require_relative '../folio_request'
+
 # Module to encapsulate org category methods used by organizations rake tasks
 module OrgCategoryTaskHelpers
+  include FolioRequestHelper
+
   def category_map
     {
       '0' => category_id('Payments'),
@@ -16,7 +20,7 @@ module OrgCategoryTaskHelpers
   end
 
   def category_id(value)
-    response = FolioRequest.new.get_cql('/organizations-storage/categories', "value==#{value}")['categories']
+    response = @@folio_request.get_cql('/organizations-storage/categories', "value==#{value}")['categories']
     begin
       response[0]['id']
     rescue NoMethodError
@@ -25,6 +29,6 @@ module OrgCategoryTaskHelpers
   end
 
   def categories_post(obj)
-    FolioRequest.new.post('/organizations-storage/categories', obj.to_json)
+    @@folio_request.post('/organizations-storage/categories', obj.to_json)
   end
 end

--- a/tasks/helpers/tenant.rb
+++ b/tasks/helpers/tenant.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
+require_relative '../helpers/folio_request'
+
 # rubocop: disable Metrics/ModuleLength
 # Module to encapsulate methods used by tenant_settings rake tasks
 module TenantTaskHelpers
-  def folio_request
-    FolioRequest.new
-  end
+  include FolioRequestHelper
 
   # Institutions
   def institutions_csv
@@ -13,7 +13,7 @@ module TenantTaskHelpers
   end
 
   def institutions_post(obj)
-    folio_request.post('/location-units/institutions', obj.to_json)
+    @@folio_request.post('/location-units/institutions', obj.to_json)
   end
 
   # Campuses
@@ -28,7 +28,7 @@ module TenantTaskHelpers
   end
 
   def campuses_post(obj)
-    folio_request.post('/location-units/campuses', obj.to_json)
+    @@folio_request.post('/location-units/campuses', obj.to_json)
   end
 
   # Libraries
@@ -44,7 +44,7 @@ module TenantTaskHelpers
   end
 
   def libraries_post(obj)
-    folio_request.post('/location-units/libraries', obj.to_json)
+    @@folio_request.post('/location-units/libraries', obj.to_json)
   end
 
   #  Service points
@@ -77,23 +77,23 @@ module TenantTaskHelpers
   end
 
   def hold_cql
-    folio_request.get_cql('/staff-slips-storage/staff-slips', 'name==Hold')['staffSlips'][0]['id']
+    @@folio_request.get_cql('/staff-slips-storage/staff-slips', 'name==Hold')['staffSlips'][0]['id']
   end
 
   def transit_cql
-    folio_request.get_cql('/staff-slips-storage/staff-slips', 'name==Transit')['staffSlips'][0]['id']
+    @@folio_request.get_cql('/staff-slips-storage/staff-slips', 'name==Transit')['staffSlips'][0]['id']
   end
 
   def pick_slip_cql
-    folio_request.get_cql('/staff-slips-storage/staff-slips', 'name==Pick%20slip')['staffSlips'][0]['id']
+    @@folio_request.get_cql('/staff-slips-storage/staff-slips', 'name==Pick%20slip')['staffSlips'][0]['id']
   end
 
   def request_delivery_cql
-    folio_request.get_cql('/staff-slips-storage/staff-slips', 'name==Request%20delivery')['staffSlips'][0]['id']
+    @@folio_request.get_cql('/staff-slips-storage/staff-slips', 'name==Request%20delivery')['staffSlips'][0]['id']
   end
 
   def service_points_post(obj)
-    folio_request.post('/service-points', obj.to_json)
+    @@folio_request.post('/service-points', obj.to_json)
   end
 
   #  Locations
@@ -121,7 +121,7 @@ module TenantTaskHelpers
   end
 
   def locations_post(obj)
-    folio_request.post('/locations', obj.to_json)
+    @@folio_request.post('/locations', obj.to_json)
   end
 
   # tenant addresses
@@ -147,11 +147,11 @@ module TenantTaskHelpers
   end
 
   def addresses_delete(id)
-    folio_request.delete("/configurations/entries/#{id}")
+    @@folio_request.delete("/configurations/entries/#{id}")
   end
 
   def addresses_post(obj)
-    folio_request.post('/configurations/entries', obj.to_json)
+    @@folio_request.post('/configurations/entries', obj.to_json)
   end
 end
 # rubocop: enable Metrics/ModuleLength

--- a/tasks/helpers/tsv_user.rb
+++ b/tasks/helpers/tsv_user.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
+require_relative '../helpers/folio_request'
+
 # Module to encapsulate methods used by user_settings rake tasks
 module TsvUserTaskHelpers
+  include FolioRequestHelper
+
   def user_acq_units_and_permission_sets_tsv
     CSV.parse(File.open("#{Settings.tsv}/users/user-acq-units-and-permission-sets.tsv"),
               headers: true, col_sep: "\t").map(&:to_h)
@@ -21,11 +25,11 @@ module TsvUserTaskHelpers
   end
 
   def note_types_post(obj)
-    FolioRequest.new.post('/note-types', obj)
+    @@folio_request.post('/note-types', obj)
   end
 
   def user_id(barcode)
-    FolioRequest.new.get_cql('/users', "barcode=#{barcode}")['users'][0]&.dig('id')
+    @@folio_request.get_cql('/users', "barcode=#{barcode}")['users'][0]&.dig('id')
   end
 
   def note_json(type, note, user)
@@ -45,7 +49,7 @@ module TsvUserTaskHelpers
   end
 
   def user_notes_post(json)
-    FolioRequest.new.post('/notes', json)
+    @@folio_request.post('/notes', json)
   end
 
   def tsv_user

--- a/tasks/helpers/users.rb
+++ b/tasks/helpers/users.rb
@@ -1,17 +1,17 @@
 # frozen_string_literal: true
 
+require_relative 'folio_request'
+
 # Module to encapsulate methods used by user_settings rake tasks
 module UsersTaskHelpers
-  def folio_request
-    FolioRequest.new
-  end
+  include FolioRequestHelper
 
   def groups_csv
     CSV.parse(File.open("#{Settings.tsv}/users/patron-groups.tsv"), headers: true, col_sep: "\t").map(&:to_h)
   end
 
   def groups_post(obj)
-    folio_request.post('/groups', obj.to_json)
+    @@folio_request.post('/groups', obj.to_json)
   end
 
   def address_types_json
@@ -19,7 +19,7 @@ module UsersTaskHelpers
   end
 
   def address_types_post(hash)
-    folio_request.post('/addresstypes', hash.to_json)
+    @@folio_request.post('/addresstypes', hash.to_json)
   end
 
   def waivers_json
@@ -27,7 +27,7 @@ module UsersTaskHelpers
   end
 
   def waivers_post(hash)
-    folio_request.post('/waives', hash.to_json)
+    @@folio_request.post('/waives', hash.to_json)
   end
 
   def payments_json
@@ -35,7 +35,7 @@ module UsersTaskHelpers
   end
 
   def payments_post(hash)
-    folio_request.post('/payments', hash.to_json)
+    @@folio_request.post('/payments', hash.to_json)
   end
 
   def refunds_json
@@ -43,7 +43,7 @@ module UsersTaskHelpers
   end
 
   def refunds_post(hash)
-    folio_request.post('/refunds', hash.to_json)
+    @@folio_request.post('/refunds', hash.to_json)
   end
 
   def fee_fine_owners_json
@@ -51,19 +51,19 @@ module UsersTaskHelpers
   end
 
   def fee_fine_owners_post(hash)
-    folio_request.post('/owners', hash.to_json)
+    @@folio_request.post('/owners', hash.to_json)
   end
 
   def user_get(username)
-    folio_request.get_cql('/users', "username==#{username}")
+    @@folio_request.get_cql('/users', "username==#{username}")
   end
 
   def user_update(user)
-    folio_request.post('/user-import', user.to_json)
+    @@folio_request.post('/user-import', user.to_json)
   end
 
   def patron_group_get(id)
-    folio_request.get("/groups/#{id}")
+    @@folio_request.get("/groups/#{id}")
   end
 
   def patron_group(user)
@@ -84,10 +84,10 @@ module UsersTaskHelpers
   end
 
   def permission_sets_post(hash)
-    folio_request.post('/perms/permissions', hash.to_json)
+    @@folio_request.post('/perms/permissions', hash.to_json)
   end
 
   def user_permissions_get(uuid)
-    folio_request.get("/perms/users/#{uuid}/permissions?full=true&indexField=userId")
+    @@folio_request.get("/perms/users/#{uuid}/permissions?full=true&indexField=userId")
   end
 end

--- a/tasks/helpers/uuids.rb
+++ b/tasks/helpers/uuids.rb
@@ -1,10 +1,14 @@
 # frozen_string_literal: true
 
+require_relative 'folio_request'
+
 # Folio UUIDs
 module Uuids
+  include FolioRequestHelper
+
   def libraries
     libraries_hash = {}
-    folio_request.get('/location-units/libraries?limit=99')['loclibs'].each do |obj|
+    @@folio_request.get('/location-units/libraries?limit=99')['loclibs'].each do |obj|
       libraries_hash[obj['code']] = obj['id']
     end
     libraries_hash
@@ -12,7 +16,7 @@ module Uuids
 
   def institutions
     institutions_hash = {}
-    folio_request.get('/location-units/institutions')['locinsts'].each do |obj|
+    @@folio_request.get('/location-units/institutions')['locinsts'].each do |obj|
       institutions_hash[obj['code']] = obj['id']
     end
     institutions_hash
@@ -20,7 +24,7 @@ module Uuids
 
   def campuses
     campuses_hash = {}
-    folio_request.get('/location-units/campuses?limit=999')['loccamps'].each do |obj|
+    @@folio_request.get('/location-units/campuses?limit=999')['loccamps'].each do |obj|
       campuses_hash[obj['code']] = obj['id']
     end
     campuses_hash
@@ -28,7 +32,7 @@ module Uuids
 
   def service_points
     service_points_hash = {}
-    folio_request.get('/service-points?limit=999')['servicepoints'].each do |obj|
+    @@folio_request.get('/service-points?limit=999')['servicepoints'].each do |obj|
       service_points_hash[obj['code']] = obj['id']
     end
     service_points_hash
@@ -36,7 +40,7 @@ module Uuids
 
   def service_point_names
     service_points_hash = {}
-    folio_request.get('/service-points?limit=999')['servicepoints'].each do |obj|
+    @@folio_request.get('/service-points?limit=999')['servicepoints'].each do |obj|
       service_points_hash[obj['name']] = obj['id']
     end
     service_points_hash
@@ -44,7 +48,7 @@ module Uuids
 
   def payment_owners
     owners_hash = {}
-    folio_request.get('/owners?limit=99')['owners'].each do |obj|
+    @@folio_request.get('/owners?limit=99')['owners'].each do |obj|
       owners_hash[obj['owner']] = obj['id']
     end
     owners_hash
@@ -52,7 +56,7 @@ module Uuids
 
   def tenant_addresses
     addresses_hash = {}
-    folio_request.get('/configurations/entries?query=configName==tenant.addresses&limit=99')['configs'].each do |obj|
+    @@folio_request.get('/configurations/entries?query=configName==tenant.addresses&limit=99')['configs'].each do |obj|
       addresses_hash[obj['code']] = obj['id']
     end
     addresses_hash
@@ -60,7 +64,7 @@ module Uuids
 
   def note_types
     note_types = {}
-    folio_request.get('/note-types?limit=99')['noteTypes'].each do |obj|
+    @@folio_request.get('/note-types?limit=99')['noteTypes'].each do |obj|
       note_types[obj['name']] = obj['id']
     end
     note_types

--- a/tasks/inventory/load_item_settings.rake
+++ b/tasks/inventory/load_item_settings.rake
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'csv'
-require_relative '../../lib/folio_request'
 require_relative '../helpers/inventory'
 
 namespace :inventory do

--- a/tasks/tenant/delete_tenant_settings.rake
+++ b/tasks/tenant/delete_tenant_settings.rake
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'csv'
-require_relative '../../lib/folio_request'
 require_relative '../helpers/tenant'
 require_relative '../helpers/uuids'
 

--- a/tasks/tenant/load_tenant_settings.rake
+++ b/tasks/tenant/load_tenant_settings.rake
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'csv'
-require_relative '../../lib/folio_request'
 require_relative '../helpers/tenant'
 require_relative '../helpers/uuids'
 

--- a/tasks/users/assign_acquisition_units.rake
+++ b/tasks/users/assign_acquisition_units.rake
@@ -8,11 +8,11 @@ namespace :tsv_users do
   desc 'assign acquisition units to a user'
   task :assign_acquisition_units do
     acq_unit_hash = {}
-    folio_request.get('/acquisitions-units/units')['acquisitionsUnits'].each do |obj|
+    @@folio_request.get('/acquisitions-units/units')['acquisitionsUnits'].each do |obj|
       acq_unit_hash[obj['name']] = obj['id']
     end
     membership_hash = {}
-    folio_request.get('/acquisitions-units/memberships?limit=10000')['acquisitionsUnitMemberships'].each do |obj|
+    @@folio_request.get('/acquisitions-units/memberships?limit=10000')['acquisitionsUnitMemberships'].each do |obj|
       key = obj['acquisitionsUnitId'] + obj['userId']
       membership_hash[key] = obj['id']
     end
@@ -23,7 +23,7 @@ namespace :tsv_users do
       users && users['users'].each do |user|
         if acq_unit_id && !membership_hash[acq_unit_id + user['id']]
           acq_membership_obj = { 'userId' => user['id'], 'acquisitionsUnitId' => acq_unit_id }
-          folio_request.post('/acquisitions-units/memberships', acq_membership_obj.to_json)
+          @@folio_request.post('/acquisitions-units/memberships', acq_membership_obj.to_json)
         end
       end
     end

--- a/tasks/users/assign_permission_sets.rake
+++ b/tasks/users/assign_permission_sets.rake
@@ -11,7 +11,7 @@ namespace :tsv_users do
     psets_from_cols.delete('SUNetID')
     psets_from_cols.delete('Acq Unit')
     pset_hash = {}
-    folio_request.get('/perms/permissions?length=10000&query=(mutable==true)')['permissions'].each do |permission|
+    @@folio_request.get('/perms/permissions?length=10000&query=(mutable==true)')['permissions'].each do |permission|
       pset_hash[permission['displayName']] = permission['id']
     end
     user_acq_units_and_permission_sets_tsv.each do |line|
@@ -19,14 +19,14 @@ namespace :tsv_users do
       username && username['users'].each do |user|
         user_permissions_get(user['id'])['permissionNames'].each do |permission|
           if permission['mutable'] && (psets_from_cols.include? permission['displayName'])
-            folio_request
+            @@folio_request
               .delete("/perms/users/#{user['id']}/permissions/#{permission['permissionName']}?indexField=userId")
           end
         end
         psets_from_cols.each do |pset|
           if line[pset] && pset_hash[pset]
             pset_obj = { 'permissionName' => pset_hash[pset] }
-            folio_request.post("/perms/users/#{user['id']}/permissions?indexField=userId", pset_obj.to_json)
+            @@folio_request.post("/perms/users/#{user['id']}/permissions?indexField=userId", pset_obj.to_json)
           end
         end
       end

--- a/tasks/users/load_permission_sets.rake
+++ b/tasks/users/load_permission_sets.rake
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'csv'
-require_relative '../../lib/folio_request'
 require_relative '../helpers/users'
 
 namespace :users do

--- a/tasks/users/load_user_settings.rake
+++ b/tasks/users/load_user_settings.rake
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'csv'
-require_relative '../../lib/folio_request'
 require_relative '../helpers/users'
 
 namespace :users do


### PR DESCRIPTION
This creates a FolioRequestHelper module with a class variable for the FolioRequest class. Each of the other helper modules include this, so now everywhere we can call FolioRequest as `@@folio_request` and it will not attempt to get new session tokens for every request.

I tries changing the modules into classes and inheriting the FolioRequest class, but it does not work well with the Rake tasks, so this is the best I could come up with.

Fixes https://github.com/sul-dlss/folio_api_client/issues/72