### PR TITLE
Adds rake task for loading migration error vendors for SUL and Law.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -26,8 +26,9 @@ task load_finance_settings: %i[acquisitions:load_fund_types
                                acquisitions:load_finance_groups
                                acquisitions:load_funds
                                acquisitions:load_budgets]
-desc 'Loads all organization settings and data: [organization categories, organizations for SUL, Business, and Law, and CORAL]'
+desc 'Loads all organization settings and data: [organization categories, SUL and Law migration error organizations, organizations for SUL, Business, and Law, and CORAL]'
 task load_organizations_all: %i[acquisitions:load_org_categories
+                                acquisitions:load_org_migrate_err
                                 acquisitions:load_org_vendors_sul
                                 acquisitions:load_org_vendors_business
                                 acquisitions:load_org_vendors_law

--- a/spec/acquisitions/load_organizations_task_spec.rb
+++ b/spec/acquisitions/load_organizations_task_spec.rb
@@ -5,6 +5,7 @@ require 'spec_helper'
 
 describe 'organizations rake tasks' do
   let(:load_categories_task) { Rake.application.invoke_task 'acquisitions:load_org_categories' }
+  let(:load_migrate_err_task) { Rake.application.invoke_task 'acquisitions:load_org_migrate_err' }
   let(:load_organizations_task) { Rake.application.invoke_task 'acquisitions:load_org_vendors_sul' }
   let(:load_law_organizations_task) { Rake.application.invoke_task 'acquisitions:load_org_vendors_law' }
   let(:load_bus_organizations_task) { Rake.application.invoke_task 'acquisitions:load_org_vendors_business' }
@@ -32,6 +33,22 @@ describe 'organizations rake tasks' do
   context 'when loading organizations categories' do
     it 'creates the hash key and value for category' do
       expect(load_categories_task.send(:categories_csv)[0]['value']).to eq 'Claims'
+    end
+  end
+
+  context 'when loading migration error organizations' do
+    let(:org_hash) { load_migrate_err_task.send(:migrate_error_orgs, 'SUL', 'acq-123') }
+
+    it 'creates the hash key and value for name' do
+      expect(org_hash['name']).to eq 'SUL Migration Error'
+    end
+
+    it 'creates the hash key and value for code' do
+      expect(org_hash['code']).to eq 'MIGRATE-ERR-SUL'
+    end
+
+    it 'creates the hash key and value for acqUnitIds' do
+      expect(org_hash['acqUnitIds']).to include 'acq-123'
     end
   end
 

--- a/tasks/acquisitions/load_organizations.rake
+++ b/tasks/acquisitions/load_organizations.rake
@@ -18,6 +18,13 @@ namespace :acquisitions do
     end
   end
 
+  desc 'load migration error org into folio'
+  task :load_org_migrate_err do
+    AcquisitionsUuidsHelpers.acq_units.slice('SUL', 'Law').each do |name, uuid|
+      organizations_post(migrate_error_orgs(name, uuid))
+    end
+  end
+
   desc 'load SUL vendor organizations into folio'
   task :load_org_vendors_sul do
     acq_unit = 'SUL'

--- a/tasks/helpers/organizations/organizations.rb
+++ b/tasks/helpers/organizations/organizations.rb
@@ -39,6 +39,16 @@ module OrganizationsTaskHelpers
     obj
   end
 
+  def migrate_error_orgs(acq_unit, acq_unit_uuid)
+    {
+      'name' => "#{acq_unit} Migration Error",
+      'code' => "MIGRATE-ERR-#{acq_unit}",
+      'status' => 'Active',
+      'isVendor' => true,
+      'acqUnitIds' => [acq_unit_uuid]
+    }
+  end
+
   def vendor_code(obj, acq_unit)
     "#{obj.at_xpath('vendorID')&.text}-#{acq_unit}"
   end


### PR DESCRIPTION
This is so looking up the vendor UUID when loading orders does not break; we will use the migration error vendor if no SUL or Law vendor can be found for a particular order.