### PR TITLE
Bug fixes for loading tsv users

### DIFF
--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -26,16 +26,16 @@ inactive_users_file: 'spec/fixtures/folio_err.log'
 # This should be is ordered from highest to lowest Rank
 # https://docs.google.com/spreadsheets/d/10n77Zxgp3GCgwB9pPR80CZzNs6ERDzQkyCuolUQEoG0
 groups_ranked:
-  - Faculty
-  - Staff
-  - Staff-Casual
-  - Fellow
-  - Visiting Scholar
-  - Courtesy
-  - Postdoctoral
-  - Graduate
-  - Undergraduate
-  - Affiliate-Sponsored-Eresources
+  - faculty
+  - staff
+  - staff-casual
+  - fellow
+  - visiting scholar
+  - courtesy
+  - postdoctoral
+  - graduate
+  - undergraduate
+  - affiliate-sponsored-eresources
 
 faculty:
   - faculty

--- a/lib/modules/patron_groups.rb
+++ b/lib/modules/patron_groups.rb
@@ -33,7 +33,7 @@ class PatronGroups
       )
   end
 
-  def undergraduate
+  def undergrad
     @aff['type'].start_with?('student') && affiliation_description.include?('undergraduate')
   end
 

--- a/spec/users/xml_user_spec.rb
+++ b/spec/users/xml_user_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe XmlUser do
       # end
 
       it 'has the correct patron group' do
-        expect(JSON.parse(result.to_json)['users'][0]['patronGroup']).to eq 'Staff'
+        expect(JSON.parse(result.to_json)['users'][0]['patronGroup']).to eq 'staff'
       end
     end
 
@@ -90,7 +90,7 @@ RSpec.describe XmlUser do
       end
 
       it 'has the correct patron group' do
-        expect(JSON.parse(result.to_json)['users'][0]['patronGroup']).to eq 'Postdoctoral'
+        expect(JSON.parse(result.to_json)['users'][0]['patronGroup']).to eq 'postdoctoral'
       end
     end
 
@@ -100,7 +100,7 @@ RSpec.describe XmlUser do
       end
 
       it 'has the correct patron group' do
-        expect(JSON.parse(result.to_json)['users'][0]['patronGroup']).to eq 'Graduate'
+        expect(JSON.parse(result.to_json)['users'][0]['patronGroup']).to eq 'graduate'
       end
     end
 
@@ -114,7 +114,7 @@ RSpec.describe XmlUser do
         # no patronGroup b/c active is false (effective and until dates are nil)
         # in Symphony, user record gets no USER_PROFILE and therefore not loaded
         # Should these get FOLIO records?
-        expect(JSON.parse(result.to_json)['users'][0]['patronGroup']).to eq 'Affiliate-Sponsored-Eresources'
+        expect(JSON.parse(result.to_json)['users'][0]['patronGroup']).to eq 'affiliate-sponsored-eresources'
       end
     end
   end

--- a/tasks/helpers/tsv_user.rb
+++ b/tasks/helpers/tsv_user.rb
@@ -12,7 +12,8 @@ module TsvUserTaskHelpers
   end
 
   def users_tsv
-    CSV.parse(File.open("#{Settings.tsv}/users/tsv_users.tsv"), liberal_parsing: true, headers: true, col_sep: "\t").map(&:to_h)
+    CSV.parse(File.open("#{Settings.tsv}/users/tsv_users.tsv"), liberal_parsing: true, headers: true, col_sep: "\t")
+       .map(&:to_h)
   end
 
   def user_notes(note_type)

--- a/tasks/helpers/tsv_user.rb
+++ b/tasks/helpers/tsv_user.rb
@@ -12,7 +12,7 @@ module TsvUserTaskHelpers
   end
 
   def users_tsv
-    CSV.parse(File.open("#{Settings.tsv}/users/tsv_users.tsv"), headers: true, col_sep: "\t").map(&:to_h)
+    CSV.parse(File.open("#{Settings.tsv}/users/tsv_users.tsv"), liberal_parsing: true, headers: true, col_sep: "\t").map(&:to_h)
   end
 
   def user_notes(note_type)

--- a/tasks/users/load_tsv_users.rake
+++ b/tasks/users/load_tsv_users.rake
@@ -30,6 +30,7 @@ namespace :tsv_users do
 
   desc 'load all user note types and notes'
   task :load_all_user_notes_types do
+    Rake::Task['tsv_users:load_user_note_types'].invoke
     task = Rake::Task['tsv_users:load_user_notes']
     user_note_types.each do |hash|
       type = hash['name']


### PR DESCRIPTION
We need to match the casing of the default reference data from folio.
Use liberal parsing of tsv files to handle cases when there are quotation marks.
Makes sure the user notes dependent rake task is invoked for the uber-task.