### PR TITLE
Adds task to pull original permission sets. Fixes tsv_users bug

### DIFF
--- a/spec/users/load_tsv_users_task_spec.rb
+++ b/spec/users/load_tsv_users_task_spec.rb
@@ -27,7 +27,7 @@ describe 'loading tsv users who do not have registry ids' do
     end
 
     it 'creates a hash with a patronGroup' do
-      expect(load_tsv_users_task.send(:tsv_user)['users'][0]['patronGroup']).to eq 'Courtesy'
+      expect(load_tsv_users_task.send(:tsv_user)['users'][0]['patronGroup']).to eq 'courtesy'
     end
 
     it 'creates a hash with en enrollment date' do

--- a/tasks/helpers/tsv_user.rb
+++ b/tasks/helpers/tsv_user.rb
@@ -69,7 +69,7 @@ module TsvUserTaskHelpers
     user['username'] = user.values[0]
     user['barcode'] = user.values[0]
     user['externalSystemId'] = user.values[1]
-    user['patronGroup'] = 'Courtesy'
+    user['patronGroup'] = 'courtesy'
     user['personal'] = user_personal(user)
     user['enrollmentDate'] = enrollment(user['PRIV_GRANTED'])
     user['expirationDate'] = expiration(user['PRIV_EXPIRED'])

--- a/tasks/helpers/users.rb
+++ b/tasks/helpers/users.rb
@@ -114,4 +114,10 @@ module UsersTaskHelpers
     trim_hash(hash, 'payments')
     hash.to_json
   end
+
+  def pull_permission_sets
+    hash = @@folio_request.get('/perms/permissions?limit=9999&length=9999&query=mutable==true')
+    trim_hash(hash, 'permissions')
+    hash.to_json
+  end
 end

--- a/tasks/pull_json.rake
+++ b/tasks/pull_json.rake
@@ -35,6 +35,13 @@ namespace :users do
       File.open("#{dir}/users/payments.json", 'w') { |file| file.puts pull_payments }
     end
   end
+
+  desc 'pull permission sets from original folio instance (use STAGE=orig yaml)'
+  task :pull_permission_sets do
+    json_files.each do |dir|
+      File.open("#{dir}/users/permission_sets.json", 'w') { |file| file.puts pull_permission_sets }
+    end
+  end
 end
 
 namespace :data_import do


### PR DESCRIPTION
Fixes #43 Adds task to pull original permission sets. Fixes tsv_users to match new lower-case patron groups that match default folio reference data.