### PR TITLE
Refactor acq units to avoid repeated top level variable warning

### DIFF
--- a/spec/acquisitions/load_acq_units_task_spec.rb
+++ b/spec/acquisitions/load_acq_units_task_spec.rb
@@ -10,8 +10,8 @@ describe 'acquisitions units rake tasks' do
     stub_request(:post, 'http://example.com/authn/login')
       .with(body: Settings.okapi.login_params.to_h)
 
-    stub_request(:post, 'http://example.com/acquisitions-units-storage/units')
-    stub_request(:get, 'http://example.com/acquisitions-units-storage/units')
+    stub_request(:post, 'http://example.com/acquisitions-units/units')
+    stub_request(:get, 'http://example.com/acquisitions-units/units')
       .with(query: hash_including)
       .to_return(body: '{ "acquisitionsUnits": [{ "id": "acq-123" }] }')
   end

--- a/spec/acquisitions/load_finance_settings_task_spec.rb
+++ b/spec/acquisitions/load_finance_settings_task_spec.rb
@@ -30,7 +30,7 @@ describe 'finance settings rake tasks' do
       .to_return(body: '{ "expenseClasses": [{ "id": "exp-123", "code": "12345" },
                                              { "id": "exp-456", "code": "67890" }] }')
 
-    stub_request(:get, 'http://example.com/acquisitions-units-storage/units')
+    stub_request(:get, 'http://example.com/acquisitions-units/units')
       .with(query: hash_including)
       .to_return(body: '{ "acquisitionsUnits": [{ "id": "acq-123", "name": "acq_unit1" },
                                                 { "id": "acq-456", "name": "acq_unit2" },

--- a/spec/acquisitions/load_law_orders_task_spec.rb
+++ b/spec/acquisitions/load_law_orders_task_spec.rb
@@ -32,7 +32,7 @@ describe 'load LAW orders rake tasks' do
 
     stub_request(:post, 'http://example.com/orders/composite-orders')
 
-    stub_request(:get, 'http://example.com/acquisitions-units-storage/units')
+    stub_request(:get, 'http://example.com/acquisitions-units/units')
       .with(query: hash_including)
       .to_return(body: '{ "acquisitionsUnits": [{ "id": "acq-123", "name": "Law" }] }')
 

--- a/spec/acquisitions/load_organizations_task_spec.rb
+++ b/spec/acquisitions/load_organizations_task_spec.rb
@@ -17,7 +17,7 @@ describe 'organizations rake tasks' do
 
     stub_request(:post, 'http://example.com/organizations-storage/categories')
 
-    stub_request(:get, 'http://example.com/acquisitions-units-storage/units')
+    stub_request(:get, 'http://example.com/acquisitions-units/units')
       .with(query: hash_including)
       .to_return(body: '{ "acquisitionsUnits": [{ "id": "acq-123", "name": "SUL" },
                                                 { "id": "acq-123", "name": "Law" },

--- a/spec/acquisitions/load_sul_orders_task_spec.rb
+++ b/spec/acquisitions/load_sul_orders_task_spec.rb
@@ -25,7 +25,7 @@ describe 'load SUL orders rake tasks' do
 
     stub_request(:post, 'http://example.com/orders/composite-orders')
 
-    stub_request(:get, 'http://example.com/acquisitions-units-storage/units')
+    stub_request(:get, 'http://example.com/acquisitions-units/units')
       .with(query: hash_including)
       .to_return(body: '{ "acquisitionsUnits": [{ "id": "acq-123", "name": "SUL" }] }')
 

--- a/spec/acquisitions/update_finance_settings_task_spec.rb
+++ b/spec/acquisitions/update_finance_settings_task_spec.rb
@@ -23,7 +23,7 @@ describe 'finance settings rake tasks' do
       .to_return(body: '{ "expenseClasses": [{ "id": "exp-123", "code": "12345" },
                                              { "id": "exp-456", "code": "67890" }] }')
 
-    stub_request(:get, 'http://example.com/acquisitions-units-storage/units')
+    stub_request(:get, 'http://example.com/acquisitions-units/units')
       .with(query: hash_including)
       .to_return(body: '{ "acquisitionsUnits": [{ "id": "acq-123", "name": "acq_unit1" },
                                                 { "id": "acq-456", "name": "acq_unit2" },

--- a/spec/acquisitions/update_organizations_task_spec.rb
+++ b/spec/acquisitions/update_organizations_task_spec.rb
@@ -12,7 +12,7 @@ describe 'update organizations rake tasks' do
     stub_request(:post, 'http://example.com/authn/login')
       .with(body: Settings.okapi.login_params.to_h)
 
-    stub_request(:get, 'http://example.com/acquisitions-units-storage/units')
+    stub_request(:get, 'http://example.com/acquisitions-units/units')
       .with(query: hash_including)
       .to_return(body: '{ "acquisitionsUnits": [{ "id": "acq-123" }] }')
 

--- a/spec/users/assign_acquisition_units_spec.rb
+++ b/spec/users/assign_acquisition_units_spec.rb
@@ -5,6 +5,9 @@ require 'spec_helper'
 
 describe 'assign acquisition units rake tasks' do
   let(:assign_acquisition_units_task) { Rake.application.invoke_task 'tsv_users:assign_acquisition_units' }
+  let(:acq_unit_hash) { AcquisitionsUuidsHelpers.acq_units }
+  let(:membership_hash) { AcquisitionsUuidsHelpers.acq_unit_membership }
+  let(:assign_acq_units) { assign_acquisition_units_task.send(:acq_units_assign, acq_unit_hash, membership_hash) }
 
   before do
     stub_request(:post, 'http://example.com/authn/login')
@@ -38,35 +41,32 @@ describe 'assign acquisition units rake tasks' do
             }
           ]
         }')
+
+    stub_request(:post, 'http://example.com/acquisitions-units/memberships')
   end
 
   context 'when assigning a user to an existing acquisitions unit' do
-    before do
-      stub_request(:post, 'http://example.com/acquisitions-units/memberships')
-        .with(body: '{"userId":"userId","acquisitionsUnitId":"acquisitionsUnitId"}')
-    end
-
     it 'has an array size that matches the number of lines in the tsv file' do
-      expect(assign_acquisition_units_task.send(:user_acq_units_and_permission_sets_tsv).size).to eq 2
+      expect(assign_acq_units.send(:user_acq_units_and_permission_sets_tsv).size).to eq 2
     end
 
     it 'has SUNetId of sunetId1' do
-      expect(assign_acquisition_units_task.send(:user_acq_units_and_permission_sets_tsv)[0]['SUNetID']).to eq 'sunetId1'
+      expect(assign_acq_units.send(:user_acq_units_and_permission_sets_tsv)[0]['SUNetID']).to eq 'sunetId1'
     end
 
     it 'has Acq Unit assignment of acquisitionsUnitName' do
-      expect(assign_acquisition_units_task.send(:user_acq_units_and_permission_sets_tsv)[0]['Acq Unit'])
+      expect(assign_acq_units.send(:user_acq_units_and_permission_sets_tsv)[0]['Acq Unit'])
         .to eq 'acquisitionsUnitName'
     end
   end
 
   context 'when assigning a user to a non-existent acquisitions unit' do
     it 'has SUNetId of sunetId2' do
-      expect(assign_acquisition_units_task.send(:user_acq_units_and_permission_sets_tsv)[1]['SUNetID']).to eq 'sunetId2'
+      expect(assign_acq_units.send(:user_acq_units_and_permission_sets_tsv)[1]['SUNetID']).to eq 'sunetId2'
     end
 
     it 'has no Acq Unit assignment of missingAcquisitionsUnitName' do
-      expect(assign_acquisition_units_task.send(:user_acq_units_and_permission_sets_tsv)[1]['Acq Unit'])
+      expect(assign_acq_units.send(:user_acq_units_and_permission_sets_tsv)[1]['Acq Unit'])
         .to eq 'missingAcquisitionsUnitName'
     end
   end

--- a/tasks/helpers/acq_units.rb
+++ b/tasks/helpers/acq_units.rb
@@ -29,25 +29,8 @@ module AcquisitionsUnitsTaskHelpers
     @@folio_request.post('/acquisitions-units-storage/units', obj.to_json)
   end
 
-  def acq_unit_hash
-    acq_unit_hash = {}
-    @@folio_request.get('/acquisitions-units/units')['acquisitionsUnits'].each do |obj|
-      acq_unit_hash[obj['name']] = obj['id']
-    end
-    acq_unit_hash
-  end
-
-  def membership_hash
-    membership_hash = {}
-    @@folio_request.get('/acquisitions-units/memberships?limit=10000')['acquisitionsUnitMemberships'].each do |obj|
-      key = obj['acquisitionsUnitId'] + obj['userId']
-      membership_hash[key] = obj['id']
-    end
-    membership_hash
-  end
-
-  def acq_units_assign
-    user_acq_units_and_permission_sets_tsv.each do |obj|
+  def acq_units_assign(acq_unit_hash, membership_hash)
+    TsvUserTaskHelpers.user_acq_units_and_permission_sets_tsv.each do |obj|
       acq_unit = obj['Acq Unit']
       acq_unit_id = acq_unit_hash[acq_unit]
       users = user_get(obj['SUNetID'])

--- a/tasks/helpers/acq_units.rb
+++ b/tasks/helpers/acq_units.rb
@@ -28,4 +28,35 @@ module AcquisitionsUnitsTaskHelpers
   def acq_units_post(obj)
     @@folio_request.post('/acquisitions-units-storage/units', obj.to_json)
   end
+
+  def acq_unit_hash
+    acq_unit_hash = {}
+    @@folio_request.get('/acquisitions-units/units')['acquisitionsUnits'].each do |obj|
+      acq_unit_hash[obj['name']] = obj['id']
+    end
+    acq_unit_hash
+  end
+
+  def membership_hash
+    membership_hash = {}
+    @@folio_request.get('/acquisitions-units/memberships?limit=10000')['acquisitionsUnitMemberships'].each do |obj|
+      key = obj['acquisitionsUnitId'] + obj['userId']
+      membership_hash[key] = obj['id']
+    end
+    membership_hash
+  end
+
+  def acq_units_assign
+    user_acq_units_and_permission_sets_tsv.each do |obj|
+      acq_unit = obj['Acq Unit']
+      acq_unit_id = acq_unit_hash[acq_unit]
+      users = user_get(obj['SUNetID'])
+      users && users['users'].each do |user|
+        if acq_unit_id && !membership_hash[acq_unit_id + user['id']]
+          acq_membership_obj = { 'userId' => user['id'], 'acquisitionsUnitId' => acq_unit_id }
+          @@folio_request.post('/acquisitions-units/memberships', acq_membership_obj.to_json)
+        end
+      end
+    end
+  end
 end

--- a/tasks/helpers/acq_units.rb
+++ b/tasks/helpers/acq_units.rb
@@ -26,7 +26,7 @@ module AcquisitionsUnitsTaskHelpers
   end
 
   def acq_units_post(obj)
-    @@folio_request.post('/acquisitions-units-storage/units', obj.to_json)
+    @@folio_request.post('/acquisitions-units/units', obj.to_json)
   end
 
   def acq_units_assign(acq_unit_hash, membership_hash)

--- a/tasks/helpers/uuids/acquisitions.rb
+++ b/tasks/helpers/uuids/acquisitions.rb
@@ -8,10 +8,19 @@ module AcquisitionsUuidsHelpers
 
   def acq_units
     acq_unit_hash = {}
-    @@folio_request.get('/acquisitions-units-storage/units')['acquisitionsUnits'].each do |obj|
+    @@folio_request.get('/acquisitions-units/units')['acquisitionsUnits'].each do |obj|
       acq_unit_hash[obj['name']] = obj['id']
     end
     acq_unit_hash
+  end
+
+  def acq_unit_membership
+    membership_hash = {}
+    @@folio_request.get('/acquisitions-units/memberships?limit=10000')['acquisitionsUnitMemberships'].each do |obj|
+      key = obj['acquisitionsUnitId'] + obj['userId']
+      membership_hash[key] = obj['id']
+    end
+    membership_hash
   end
 
   def acquisition_methods

--- a/tasks/users/assign_acquisition_units.rake
+++ b/tasks/users/assign_acquisition_units.rake
@@ -3,29 +3,10 @@
 require_relative '../helpers/tsv_user'
 
 namespace :tsv_users do
-  include TsvUserTaskHelpers
+  include TsvUserTaskHelpers, AcquisitionsUnitsTaskHelpers
 
   desc 'assign acquisition units to a user'
   task :assign_acquisition_units do
-    acq_unit_hash = {}
-    @@folio_request.get('/acquisitions-units/units')['acquisitionsUnits'].each do |obj|
-      acq_unit_hash[obj['name']] = obj['id']
-    end
-    membership_hash = {}
-    @@folio_request.get('/acquisitions-units/memberships?limit=10000')['acquisitionsUnitMemberships'].each do |obj|
-      key = obj['acquisitionsUnitId'] + obj['userId']
-      membership_hash[key] = obj['id']
-    end
-    user_acq_units_and_permission_sets_tsv.each do |obj|
-      acq_unit = obj['Acq Unit']
-      acq_unit_id = acq_unit_hash[acq_unit]
-      users = user_get(obj['SUNetID'])
-      users && users['users'].each do |user|
-        if acq_unit_id && !membership_hash[acq_unit_id + user['id']]
-          acq_membership_obj = { 'userId' => user['id'], 'acquisitionsUnitId' => acq_unit_id }
-          @@folio_request.post('/acquisitions-units/memberships', acq_membership_obj.to_json)
-        end
-      end
-    end
+    acq_units_assign
   end
 end

--- a/tasks/users/assign_acquisition_units.rake
+++ b/tasks/users/assign_acquisition_units.rake
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative '../helpers/tsv_user'
+require_relative '../helpers/acq_units'
 
 namespace :tsv_users do
   include TsvUserTaskHelpers, AcquisitionsUnitsTaskHelpers

--- a/tasks/users/assign_acquisition_units.rake
+++ b/tasks/users/assign_acquisition_units.rake
@@ -2,12 +2,13 @@
 
 require_relative '../helpers/tsv_user'
 require_relative '../helpers/acq_units'
+require_relative '../helpers/uuids/acquisitions'
 
 namespace :tsv_users do
-  include TsvUserTaskHelpers, AcquisitionsUnitsTaskHelpers
+  include TsvUserTaskHelpers, AcquisitionsUnitsTaskHelpers, AcquisitionsUuidsHelpers
 
   desc 'assign acquisition units to a user'
   task :assign_acquisition_units do
-    acq_units_assign
+    acq_units_assign(AcquisitionsUuidsHelpers.acq_units, AcquisitionsUuidsHelpers.acq_unit_membership)
   end
 end


### PR DESCRIPTION
When `@@folio_request` is instantiated in a `.rake` file it repeatedly warns about the use of a top-level variable assignment, and while using this `@@` assignment is not the most elegant solution to the problem of repeated folio logins, it's the best I could come up with given our project structure. Moving the instantiation to a ruby module at leasts  minimizes the warnings.