### PR TITLE
Adds FolioUuid to orders and task to delete orders.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,10 +23,10 @@ Metrics/ClassLength:
   Max: 120
 
 Metrics/ModuleLength:
-  Max: 130
+  Max: 132
 
 Metrics/MethodLength:
-  Max: 20
+  Max: 22
 
 RSpec/DescribeClass:
   Enabled: false

--- a/spec/acquisitions/load_sul_orders_task_spec.rb
+++ b/spec/acquisitions/load_sul_orders_task_spec.rb
@@ -88,6 +88,10 @@ describe 'load SUL orders rake tasks' do
     end
     let(:orders_hash) { load_sul_orders_task.send(:orders_hash, order_id, sym_order, acq_unit_uuid, uuid_hashes) }
 
+    it 'has a UUID in the id field' do
+      expect(orders_hash['id']).to eq '702e48f3-2931-5c47-9767-07211e561303'
+    end
+
     it 'has the approved box checked' do
       expect(orders_hash['approved']).to be_truthy
     end

--- a/tasks/acquisitions/delete_orders.rake
+++ b/tasks/acquisitions/delete_orders.rake
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'require_all'
+require_rel '../helpers/orders'
+require_relative '../helpers/uuids/acquisitions'
+
+namespace :acquisitions do
+  include AcquisitionsUuidsHelpers, OrdersTaskHelpers
+
+  desc 'delete all orders from folio'
+  task :delete_all_orders do
+    orders_hash = AcquisitionsUuidsHelpers.orders
+    orders_hash.values do |id|
+      orders_delete(id)
+    end
+  end
+end

--- a/tasks/helpers/orders/orders.rb
+++ b/tasks/helpers/orders/orders.rb
@@ -13,6 +13,7 @@ module OrdersTaskHelpers
   def orders_hash(order_id, sym_order, acq_unit_uuid, uuid_hashes)
     addresses, organizations, order_type_map, hldg_code_loc_map, funds = uuid_hashes
     composite_orders = {
+      'id' => determine_order_uuid(cleanup_po_num(order_id), Settings.okapi.url.to_s),
       'approved' => true,
       'approvalDate' => date_format(sym_order['ORD_DATE_CREATED']),
       'dateOrdered' => date_format(sym_order['ORD_DATE_CREATED']),
@@ -31,6 +32,10 @@ module OrdersTaskHelpers
     add_notes(composite_orders, sym_order)
     add_tags(composite_orders, sym_order)
     composite_orders.compact
+  end
+
+  def determine_order_uuid(legacy_identifier, okapi_url)
+    FolioUuid.new.generate(okapi_url, 'orders', legacy_identifier)
   end
 
   def vendor_uuid(vendor_id, order_library, organizations)
@@ -157,5 +162,9 @@ module OrdersTaskHelpers
 
   def orders_post(obj)
     @@folio_request.post('/orders/composite-orders', obj.to_json)
+  end
+
+  def orders_delete(id)
+    @@folio_request.delete("/orders/composite-orders/#{id}")
   end
 end

--- a/tasks/helpers/orders/po_lines.rb
+++ b/tasks/helpers/orders/po_lines.rb
@@ -20,7 +20,7 @@ module PoLinesHelpers
       'receiptStatus' => receipt_status(po_line_data['DIST_DATE_RCVD'], order_type, order_type_map),
       'selector' => po_line_data['SELECTOR'],
       'poLineDescription' => add_fund_xinfo_field(po_line_data['FUND']),
-      'instanceId' => determine_uuid(po_line_data['CKEY'], Settings.okapi.url.to_s),
+      'instanceId' => determine_instance_uuid(po_line_data['CKEY'], Settings.okapi.url.to_s),
       'titleOrPackage' => po_line_data['TITLE'],
       'acquisitionMethod' => acquisition_method(order_type, order_type_map),
       'source' => 'API',
@@ -40,7 +40,7 @@ module PoLinesHelpers
     "FUND: #{data}"
   end
 
-  def determine_uuid(legacy_identifier, okapi_url)
+  def determine_instance_uuid(legacy_identifier, okapi_url)
     FolioUuid.new.generate(okapi_url, 'instances', legacy_identifier.prepend('a'))
   end
 

--- a/tasks/helpers/uuids/acquisitions.rb
+++ b/tasks/helpers/uuids/acquisitions.rb
@@ -97,6 +97,14 @@ module AcquisitionsUuidsHelpers
     ledgers_hash
   end
 
+  def orders
+    orders_hash = {}
+    @@folio_request.get('/orders/composite-orders?limit=99999')['purchaseOrders'].each do |obj|
+      orders_hash[obj['poNumber']] = obj['id']
+    end
+    orders_hash
+  end
+
   # rubocop: disable Layout/LineLength
   def law_organizations
     organizations_hash = {}


### PR DESCRIPTION
Closes #68 

Creates a deterministic UUID for order ID and adds a `delete_all_orders` rake task. If we find we need to delete a selection of orders, we could use the deterministic UUID to identify which orders to delete or maybe parse the orders_hash, depending on whatever is faster.