### PR TITLE
Post to credentials table first before removing password.

### DIFF
--- a/tasks/users/load_tsv_users.rake
+++ b/tasks/users/load_tsv_users.rake
@@ -15,8 +15,8 @@ namespace :tsv_users do
   desc 'load app users from tsv file'
   task :load_app_users do
     users_tsv('app_users.tsv').each do |user|
-      user_post(app_user(user))
       user_login(app_user_credentials(user))
+      user_post(app_user(user))
       puts 'Creating user record in permissions table'
       user_perms(app_user_id_hash(user))
     end


### PR DESCRIPTION
Not sure why because the password field from tsv should have still been retained, but I got this error when running the `tsv_users:load_app_users` rake task when creating the new app_mylibrary user:
```{"errors"=>
  [{"message"=>"Password is missing or empty",
    "type"=>"1",
    "code"=>"-1",
    "parameters"=>
     [{"key"=>"'userId'", "value"=>"261f8166-5543-5cc0-b7db-1507b759873d"}]}]}
     ```