### PR TITLE
Allow a post without a body

### DIFF
--- a/bin/folio_post.rb
+++ b/bin/folio_post.rb
@@ -4,6 +4,6 @@ require_relative '../lib/folio_request'
 require 'json'
 
 path = ARGV[0]
-json = JSON.parse(File.read(ARGV[1]))
+ARGV[1] && json = JSON.parse(File.read(ARGV[1]))
 folio = FolioRequest.new
-folio.post(path, json.to_json)
+json ? folio.post(path, json.to_json) : folio.post_no_body(path)

--- a/lib/folio_request.rb
+++ b/lib/folio_request.rb
@@ -30,6 +30,10 @@ class FolioRequest
     puts JSON.pretty_generate(JSON.parse(authenticated_request(path)))
   end
 
+  def post_no_body(path)
+    parse(authenticated_request(path, method: :post))
+  end
+
   def post(path, json)
     parse(authenticated_request(path, method: :post, body: json))
   end


### PR DESCRIPTION
Some API endpoints like `/authority-storage/reindex` do not require or accept a body for a POST.