### PR TITLE
Lower case object key for custom field to load properly

### DIFF
--- a/lib/xml_user.rb
+++ b/lib/xml_user.rb
@@ -65,11 +65,11 @@ class XmlUser
   end
 
   def proximity(node)
-    @person_hash['customFields']['proximityChipId'] = node.children.first&.content&.strip
+    @person_hash['customFields']['proximitychipid'] = node.children.first&.content&.strip
   end
 
   def mobile_id(node)
-    @person_hash['customFields']['mobileId'] = node.children.first&.content&.strip
+    @person_hash['customFields']['mobileid'] = node.children.first&.content&.strip
   end
 
   def person(nodes)

--- a/spec/users/xml_user_spec.rb
+++ b/spec/users/xml_user_spec.rb
@@ -61,11 +61,11 @@ RSpec.describe XmlUser do
       end
 
       it 'sets the proximityChipId custom field' do
-        expect(JSON.parse(result.to_json)['users'][0]['customFields']['proximityChipId']).to eq '0123456'
+        expect(JSON.parse(result.to_json)['users'][0]['customFields']['proximitychipid']).to eq '0123456'
       end
 
       it 'sets the mobileId custom field' do
-        expect(JSON.parse(result.to_json)['users'][0]['customFields']['mobileId']).to eq '0511111'
+        expect(JSON.parse(result.to_json)['users'][0]['customFields']['mobileid']).to eq '0511111'
       end
 
       # Use to test workgroup permissions or remove this method if we end up not needing this.


### PR DESCRIPTION
For whatever reason, the object key for a custom field HAS to be all lower case...