### PR TITLE
Adds FolioJobs helper to multi-thread loads and deletes.

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,5 +19,9 @@ jobs:
       run: bundle install --without production
     - name: Run Rubocop
       run: bundle exec rake rubocop
+    - name: Prepare test directories
+      run: | -
+        mkdir -p spec/fixtures/acquisitions/orders/json/law
+        mkdir -p spec/fixtures/acquisitions/orders/json/sul
     - name: Run tests
       run: bundle exec rspec

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Run Rubocop
       run: bundle exec rake rubocop
     - name: Prepare test directories
-      run: | -
+      run: |
         mkdir -p spec/fixtures/acquisitions/orders/json/law
         mkdir -p spec/fixtures/acquisitions/orders/json/sul
     - name: Run tests

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /tsv
 /xml
 /json/**/*.json
+spec/fixtures/acquisitions/orders/json

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,7 @@ require:
  - rubocop-rspec
 
 AllCops:
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 2.7.1
   Exclude:
     - 'Gemfile'
     - 'Rakefile'

--- a/Rakefile
+++ b/Rakefile
@@ -74,24 +74,22 @@ task load_new_data_and_settings: %i[load_user_settings
                                     load_order_settings
                                     load_organizations_all]
 
-desc 'Prepare SUL order data: [create yaml files, add order and orderline xinfo to yaml files]'
-task prepare_sul_orders: %i[acquisitions:create_sul_orders_yaml
-                            acquisitions:add_sul_order_xinfo_to_yaml
-                            acquisitions:add_sul_orderlin1_xinfo_to_yaml
-                            acquisitions:add_sul_orderline_xinfo_to_yaml]
+desc 'Process Symphony order data for SUL and LAW: [create yaml files, add xinfo fields to yaml, transform to folio orders]'
+task prepare_orders: %i[acquisitions:create_sul_orders_yaml
+                        acquisitions:add_sul_order_xinfo
+                        acquisitions:add_sul_orderlin1
+                        acquisitions:add_sul_orderline
+                        acquisitions:transform_sul_orders
+                        acquisitions:create_law_orders_yaml
+                        acquisitions:add_law_order_xinfo
+                        acquisitions:add_law_orderlin1_xinfo
+                        acquisitions:add_law_orderline_xinfo
+                        acquisitions:transform_law_orders]
 
-desc 'Load SUL order data and tags: [tags for SUL order, SUL orders]'
-task load_orders_tags_sul: %i[acquisitions:load_tags_orders_sul
-                              acquisitions:load_orders_sul]
-
-desc 'Prepare LAW order data: [create yaml files, add order and orderline xinfo to yaml files]'
-task prepare_law_orders: %i[acquisitions:create_law_orders_yaml
-                            acquisitions:add_law_order_xinfo_to_yaml
-                            acquisitions:add_law_orderlin1_xinfo_to_yaml
-                            acquisitions:add_law_orderline_xinfo_to_yaml]
-
-desc 'Load LAW order data: [Law orders]'
-task load_orders_law: %i[acquisitions:load_orders_law]
+desc 'Load SUL and LAW order data and SUL order tags'
+task load_orders: %i[acquisitions:load_tags_orders_sul
+                     acquisitions:load_sul_orders[10]
+                     acquisitions:load_law_orders[10]]
 
 desc 'Pull all json data (use STAGE=orig)'
 task pull_all_json_data: %i[users:pull_waivers

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -18,6 +18,8 @@ yaml:
 # we test against real data we GET from FOLIO before migrating
 json: spec/fixtures/json
 
+json_orders: spec/fixtures/acquisitions/orders/json
+
 # comment this out in order to use the user's real email address:
 user_email_override: foliotesting@lists.stanford.edu
 

--- a/spec/acquisitions/process_symphony_orders_spec.rb
+++ b/spec/acquisitions/process_symphony_orders_spec.rb
@@ -10,13 +10,13 @@ describe 'prepare order yaml files' do
 
   before do
     Rake.application.invoke_task 'acquisitions:create_sul_orders_yaml'
-    Rake.application.invoke_task 'acquisitions:add_sul_order_xinfo_to_yaml'
-    Rake.application.invoke_task 'acquisitions:add_sul_orderlin1_xinfo_to_yaml'
-    Rake.application.invoke_task 'acquisitions:add_sul_orderline_xinfo_to_yaml'
+    Rake.application.invoke_task 'acquisitions:add_sul_order_xinfo'
+    Rake.application.invoke_task 'acquisitions:add_sul_orderlin1_xinfo'
+    Rake.application.invoke_task 'acquisitions:add_sul_orderline_xinfo'
     Rake.application.invoke_task 'acquisitions:create_law_orders_yaml'
-    Rake.application.invoke_task 'acquisitions:add_law_order_xinfo_to_yaml'
-    Rake.application.invoke_task 'acquisitions:add_law_orderlin1_xinfo_to_yaml'
-    Rake.application.invoke_task 'acquisitions:add_law_orderline_xinfo_to_yaml'
+    Rake.application.invoke_task 'acquisitions:add_law_order_xinfo'
+    Rake.application.invoke_task 'acquisitions:add_law_orderlin1_xinfo'
+    Rake.application.invoke_task 'acquisitions:add_law_orderline_xinfo'
   end
 
   context 'when order has one orderline and one fund distribution' do

--- a/spec/acquisitions/transform_law_orders_task_spec.rb
+++ b/spec/acquisitions/transform_law_orders_task_spec.rb
@@ -3,15 +3,15 @@
 require 'rake'
 require 'spec_helper'
 
-describe 'load LAW orders rake tasks' do
-  let(:load_law_orders_task) { Rake.application.invoke_task 'acquisitions:load_orders_law' }
+describe 'transform LAW orders rake tasks' do
+  let(:transform_law_orders_task) { Rake.application.invoke_task 'acquisitions:transform_law_orders' }
   let(:acq_unit_uuid) { AcquisitionsUuidsHelpers.acq_units.fetch('Law', nil) }
   let(:order_type_map) do
-    load_law_orders_task.send(:order_type_mapping, 'order_type_map.tsv', Uuids.material_types,
-                              AcquisitionsUuidsHelpers.acquisition_methods)
+    transform_law_orders_task.send(:order_type_mapping, 'order_type_map.tsv', Uuids.material_types,
+                                   AcquisitionsUuidsHelpers.acquisition_methods)
   end
   let(:hldg_code_map) do
-    load_law_orders_task.send(:hldg_code_map, 'sym_hldg_code_location_map.tsv', Uuids.law_locations)
+    transform_law_orders_task.send(:hldg_code_map, 'sym_hldg_code_location_map.tsv', Uuids.law_locations)
   end
   let(:uuid_hashes) do
     [Uuids.tenant_addresses, AcquisitionsUuidsHelpers.law_organizations, order_type_map, hldg_code_map,
@@ -19,18 +19,16 @@ describe 'load LAW orders rake tasks' do
   end
   let(:law_order_yaml_dir) { Settings.yaml.law_orders.to_s }
   let(:order_id) do
-    load_law_orders_task.send(:get_id_data, YAML.load_file("#{law_order_yaml_dir}/56789L02.yaml")).shift
+    transform_law_orders_task.send(:get_id_data, YAML.load_file("#{law_order_yaml_dir}/56789L02.yaml")).shift
   end
   let(:sym_order) do
-    load_law_orders_task.send(:get_id_data, YAML.load_file("#{law_order_yaml_dir}/56789L02.yaml")).pop
+    transform_law_orders_task.send(:get_id_data, YAML.load_file("#{law_order_yaml_dir}/56789L02.yaml")).pop
   end
-  let(:orders_hash) { load_law_orders_task.send(:orders_hash, order_id, sym_order, acq_unit_uuid, uuid_hashes) }
+  let(:orders_hash) { transform_law_orders_task.send(:orders_hash, order_id, sym_order, acq_unit_uuid, uuid_hashes) }
 
   before do
     stub_request(:post, 'http://example.com/authn/login')
       .with(body: Settings.okapi.login_params.to_h)
-
-    stub_request(:post, 'http://example.com/orders/composite-orders')
 
     stub_request(:get, 'http://example.com/acquisitions-units/units')
       .with(query: hash_including)

--- a/spec/acquisitions/transform_law_orders_task_spec.rb
+++ b/spec/acquisitions/transform_law_orders_task_spec.rb
@@ -14,7 +14,7 @@ describe 'transform LAW orders rake tasks' do
     transform_law_orders_task.send(:hldg_code_map, 'sym_hldg_code_location_map.tsv', Uuids.law_locations)
   end
   let(:uuid_hashes) do
-    [Uuids.tenant_addresses, AcquisitionsUuidsHelpers.law_organizations, order_type_map, hldg_code_map,
+    [acq_unit_uuid, Uuids.tenant_addresses, AcquisitionsUuidsHelpers.law_organizations, order_type_map, hldg_code_map,
      AcquisitionsUuidsHelpers.law_funds]
   end
   let(:law_order_yaml_dir) { Settings.yaml.law_orders.to_s }
@@ -24,7 +24,7 @@ describe 'transform LAW orders rake tasks' do
   let(:sym_order) do
     transform_law_orders_task.send(:get_id_data, YAML.load_file("#{law_order_yaml_dir}/56789L02.yaml")).pop
   end
-  let(:orders_hash) { transform_law_orders_task.send(:orders_hash, order_id, sym_order, acq_unit_uuid, uuid_hashes) }
+  let(:orders_hash) { transform_law_orders_task.send(:orders_hash, order_id, sym_order, uuid_hashes) }
 
   before do
     stub_request(:post, 'http://example.com/authn/login')

--- a/spec/acquisitions/transform_sul_orders_task_spec.rb
+++ b/spec/acquisitions/transform_sul_orders_task_spec.rb
@@ -3,15 +3,15 @@
 require 'rake'
 require 'spec_helper'
 
-describe 'load SUL orders rake tasks' do
-  let(:load_sul_orders_task) { Rake.application.invoke_task 'acquisitions:load_orders_sul' }
+describe 'transform SUL orders rake tasks' do
+  let(:transform_sul_orders_task) { Rake.application.invoke_task 'acquisitions:transform_sul_orders' }
   let(:acq_unit_uuid) { AcquisitionsUuidsHelpers.acq_units.fetch('SUL', nil) }
   let(:order_type_map) do
-    load_sul_orders_task.send(:order_type_mapping, 'order_type_map.tsv', Uuids.material_types,
-                              AcquisitionsUuidsHelpers.acquisition_methods)
+    transform_sul_orders_task.send(:order_type_mapping, 'order_type_map.tsv', Uuids.material_types,
+                                   AcquisitionsUuidsHelpers.acquisition_methods)
   end
   let(:hldg_code_map) do
-    load_sul_orders_task.send(:hldg_code_map, 'sym_hldg_code_location_map.tsv', Uuids.sul_locations)
+    transform_sul_orders_task.send(:hldg_code_map, 'sym_hldg_code_location_map.tsv', Uuids.sul_locations)
   end
   let(:uuid_hashes) do
     [Uuids.tenant_addresses, AcquisitionsUuidsHelpers.sul_organizations, order_type_map, hldg_code_map,
@@ -22,8 +22,6 @@ describe 'load SUL orders rake tasks' do
   before do
     stub_request(:post, 'http://example.com/authn/login')
       .with(body: Settings.okapi.login_params.to_h)
-
-    stub_request(:post, 'http://example.com/orders/composite-orders')
 
     stub_request(:get, 'http://example.com/acquisitions-units/units')
       .with(query: hash_including)
@@ -81,12 +79,12 @@ describe 'load SUL orders rake tasks' do
 
   context 'when one-time orders have been received' do
     let(:order_id) do
-      load_sul_orders_task.send(:get_id_data, YAML.load_file("#{sul_order_yaml_dir}/222222F22.yaml")).shift
+      transform_sul_orders_task.send(:get_id_data, YAML.load_file("#{sul_order_yaml_dir}/222222F22.yaml")).shift
     end
     let(:sym_order) do
-      load_sul_orders_task.send(:get_id_data, YAML.load_file("#{sul_order_yaml_dir}/222222F22.yaml")).pop
+      transform_sul_orders_task.send(:get_id_data, YAML.load_file("#{sul_order_yaml_dir}/222222F22.yaml")).pop
     end
-    let(:orders_hash) { load_sul_orders_task.send(:orders_hash, order_id, sym_order, acq_unit_uuid, uuid_hashes) }
+    let(:orders_hash) { transform_sul_orders_task.send(:orders_hash, order_id, sym_order, acq_unit_uuid, uuid_hashes) }
 
     it 'has a UUID in the id field' do
       expect(orders_hash['id']).to eq '702e48f3-2931-5c47-9767-07211e561303'
@@ -151,12 +149,12 @@ describe 'load SUL orders rake tasks' do
 
   context 'when one-time orders have not been received' do
     let(:order_id) do
-      load_sul_orders_task.send(:get_id_data, YAML.load_file("#{sul_order_yaml_dir}/444444F21.yaml")).shift
+      transform_sul_orders_task.send(:get_id_data, YAML.load_file("#{sul_order_yaml_dir}/444444F21.yaml")).shift
     end
     let(:sym_order) do
-      load_sul_orders_task.send(:get_id_data, YAML.load_file("#{sul_order_yaml_dir}/444444F21.yaml")).pop
+      transform_sul_orders_task.send(:get_id_data, YAML.load_file("#{sul_order_yaml_dir}/444444F21.yaml")).pop
     end
-    let(:orders_hash) { load_sul_orders_task.send(:orders_hash, order_id, sym_order, acq_unit_uuid, uuid_hashes) }
+    let(:orders_hash) { transform_sul_orders_task.send(:orders_hash, order_id, sym_order, acq_unit_uuid, uuid_hashes) }
 
     it 'has receipt status of Awaiting Receipt' do
       expect(orders_hash['compositePoLines'][0]['receiptStatus']).to eq 'Awaiting Receipt'
@@ -177,12 +175,12 @@ describe 'load SUL orders rake tasks' do
 
   context 'when orders are ongoing subscriptions' do
     let(:order_id) do
-      load_sul_orders_task.send(:get_id_data, YAML.load_file("#{sul_order_yaml_dir}/555555F12.yaml")).shift
+      transform_sul_orders_task.send(:get_id_data, YAML.load_file("#{sul_order_yaml_dir}/555555F12.yaml")).shift
     end
     let(:sym_order) do
-      load_sul_orders_task.send(:get_id_data, YAML.load_file("#{sul_order_yaml_dir}/555555F12.yaml")).pop
+      transform_sul_orders_task.send(:get_id_data, YAML.load_file("#{sul_order_yaml_dir}/555555F12.yaml")).pop
     end
-    let(:orders_hash) { load_sul_orders_task.send(:orders_hash, order_id, sym_order, acq_unit_uuid, uuid_hashes) }
+    let(:orders_hash) { transform_sul_orders_task.send(:orders_hash, order_id, sym_order, acq_unit_uuid, uuid_hashes) }
 
     it 'has isSubscription is true' do
       expect(orders_hash['ongoing']['isSubscription']).to be_truthy
@@ -223,12 +221,12 @@ describe 'load SUL orders rake tasks' do
 
   context 'when orders are ongoing but not subscriptions' do
     let(:order_id) do
-      load_sul_orders_task.send(:get_id_data, YAML.load_file("#{sul_order_yaml_dir}/1ABC0000.yaml")).shift
+      transform_sul_orders_task.send(:get_id_data, YAML.load_file("#{sul_order_yaml_dir}/1ABC0000.yaml")).shift
     end
     let(:sym_order) do
-      load_sul_orders_task.send(:get_id_data, YAML.load_file("#{sul_order_yaml_dir}/1ABC0000.yaml")).pop
+      transform_sul_orders_task.send(:get_id_data, YAML.load_file("#{sul_order_yaml_dir}/1ABC0000.yaml")).pop
     end
-    let(:orders_hash) { load_sul_orders_task.send(:orders_hash, order_id, sym_order, acq_unit_uuid, uuid_hashes) }
+    let(:orders_hash) { transform_sul_orders_task.send(:orders_hash, order_id, sym_order, acq_unit_uuid, uuid_hashes) }
 
     it 'has order type of ongoing' do
       expect(orders_hash['orderType']).to eq 'Ongoing'
@@ -273,12 +271,12 @@ describe 'load SUL orders rake tasks' do
 
   context 'when orders have split funding by amount' do
     let(:order_id) do
-      load_sul_orders_task.send(:get_id_data, YAML.load_file("#{sul_order_yaml_dir}/333333F22.yaml")).shift
+      transform_sul_orders_task.send(:get_id_data, YAML.load_file("#{sul_order_yaml_dir}/333333F22.yaml")).shift
     end
     let(:sym_order) do
-      load_sul_orders_task.send(:get_id_data, YAML.load_file("#{sul_order_yaml_dir}/333333F22.yaml")).pop
+      transform_sul_orders_task.send(:get_id_data, YAML.load_file("#{sul_order_yaml_dir}/333333F22.yaml")).pop
     end
-    let(:orders_hash) { load_sul_orders_task.send(:orders_hash, order_id, sym_order, acq_unit_uuid, uuid_hashes) }
+    let(:orders_hash) { transform_sul_orders_task.send(:orders_hash, order_id, sym_order, acq_unit_uuid, uuid_hashes) }
     let(:po_line_fund_dist) { orders_hash['compositePoLines'][0]['fundDistribution'] }
 
     it 'has distribution type of amount' do
@@ -312,12 +310,12 @@ describe 'load SUL orders rake tasks' do
 
   context 'when orders have split funding by percentage' do
     let(:order_id) do
-      load_sul_orders_task.send(:get_id_data, YAML.load_file("#{sul_order_yaml_dir}/222222F22.yaml")).shift
+      transform_sul_orders_task.send(:get_id_data, YAML.load_file("#{sul_order_yaml_dir}/222222F22.yaml")).shift
     end
     let(:sym_order) do
-      load_sul_orders_task.send(:get_id_data, YAML.load_file("#{sul_order_yaml_dir}/222222F22.yaml")).pop
+      transform_sul_orders_task.send(:get_id_data, YAML.load_file("#{sul_order_yaml_dir}/222222F22.yaml")).pop
     end
-    let(:orders_hash) { load_sul_orders_task.send(:orders_hash, order_id, sym_order, acq_unit_uuid, uuid_hashes) }
+    let(:orders_hash) { transform_sul_orders_task.send(:orders_hash, order_id, sym_order, acq_unit_uuid, uuid_hashes) }
     let(:po_line_fund_dist) { orders_hash['compositePoLines'][0]['fundDistribution'] }
 
     it 'has distribution type of percentage' do
@@ -343,12 +341,12 @@ describe 'load SUL orders rake tasks' do
 
   context 'when extended info notes map to FOLIO order and po line fields' do
     let(:order_id) do
-      load_sul_orders_task.send(:get_id_data, YAML.load_file("#{sul_order_yaml_dir}/666666F07.yaml")).shift
+      transform_sul_orders_task.send(:get_id_data, YAML.load_file("#{sul_order_yaml_dir}/666666F07.yaml")).shift
     end
     let(:sym_order) do
-      load_sul_orders_task.send(:get_id_data, YAML.load_file("#{sul_order_yaml_dir}/666666F07.yaml")).pop
+      transform_sul_orders_task.send(:get_id_data, YAML.load_file("#{sul_order_yaml_dir}/666666F07.yaml")).pop
     end
-    let(:orders_hash) { load_sul_orders_task.send(:orders_hash, order_id, sym_order, acq_unit_uuid, uuid_hashes) }
+    let(:orders_hash) { transform_sul_orders_task.send(:orders_hash, order_id, sym_order, acq_unit_uuid, uuid_hashes) }
 
     it 'has order xinfo and orderline1 xinfo notes as list of notes' do
       expect(orders_hash['notes']).to be_kind_of Array
@@ -371,28 +369,28 @@ describe 'load SUL orders rake tasks' do
     end
 
     it 'does not have empty note fields' do
-      order_id, sym_order = load_sul_orders_task.send(:get_id_data,
-                                                      YAML.load_file("#{sul_order_yaml_dir}/555555F12.yaml"))
-      order = load_sul_orders_task.send(:orders_hash, order_id, sym_order, acq_unit_uuid, uuid_hashes)
+      order_id, sym_order = transform_sul_orders_task.send(:get_id_data,
+                                                           YAML.load_file("#{sul_order_yaml_dir}/555555F12.yaml"))
+      order = transform_sul_orders_task.send(:orders_hash, order_id, sym_order, acq_unit_uuid, uuid_hashes)
       expect(order['notes']).not_to include 'COMMENT: '
     end
 
     it 'has FUND in the poLineDescription field' do
-      order_id, sym_order = load_sul_orders_task.send(:get_id_data,
-                                                      YAML.load_file("#{sul_order_yaml_dir}/555555F12.yaml"))
-      order = load_sul_orders_task.send(:orders_hash, order_id, sym_order, acq_unit_uuid, uuid_hashes)
+      order_id, sym_order = transform_sul_orders_task.send(:get_id_data,
+                                                           YAML.load_file("#{sul_order_yaml_dir}/555555F12.yaml"))
+      order = transform_sul_orders_task.send(:orders_hash, order_id, sym_order, acq_unit_uuid, uuid_hashes)
       expect(order['compositePoLines'][0]['poLineDescription']).to eq 'FUND: ASULFUND 25%; ASULFUND 12%; ASULFUND 63%'
     end
   end
 
   context 'when order format is physical resource' do
     let(:order_id) do
-      load_sul_orders_task.send(:get_id_data, YAML.load_file("#{sul_order_yaml_dir}/222222F22.yaml")).shift
+      transform_sul_orders_task.send(:get_id_data, YAML.load_file("#{sul_order_yaml_dir}/222222F22.yaml")).shift
     end
     let(:sym_order) do
-      load_sul_orders_task.send(:get_id_data, YAML.load_file("#{sul_order_yaml_dir}/222222F22.yaml")).pop
+      transform_sul_orders_task.send(:get_id_data, YAML.load_file("#{sul_order_yaml_dir}/222222F22.yaml")).pop
     end
-    let(:orders_hash) { load_sul_orders_task.send(:orders_hash, order_id, sym_order, acq_unit_uuid, uuid_hashes) }
+    let(:orders_hash) { transform_sul_orders_task.send(:orders_hash, order_id, sym_order, acq_unit_uuid, uuid_hashes) }
 
     it 'has a locations object with quantityPhysical' do
       expect(orders_hash['compositePoLines'][0]['locations'][0]['quantityPhysical']).to eq 1
@@ -441,12 +439,12 @@ describe 'load SUL orders rake tasks' do
 
   context 'when order format is electronic resource' do
     let(:order_id) do
-      load_sul_orders_task.send(:get_id_data, YAML.load_file("#{sul_order_yaml_dir}/666666F07.yaml")).shift
+      transform_sul_orders_task.send(:get_id_data, YAML.load_file("#{sul_order_yaml_dir}/666666F07.yaml")).shift
     end
     let(:sym_order) do
-      load_sul_orders_task.send(:get_id_data, YAML.load_file("#{sul_order_yaml_dir}/666666F07.yaml")).pop
+      transform_sul_orders_task.send(:get_id_data, YAML.load_file("#{sul_order_yaml_dir}/666666F07.yaml")).pop
     end
-    let(:orders_hash) { load_sul_orders_task.send(:orders_hash, order_id, sym_order, acq_unit_uuid, uuid_hashes) }
+    let(:orders_hash) { transform_sul_orders_task.send(:orders_hash, order_id, sym_order, acq_unit_uuid, uuid_hashes) }
 
     it 'has a locations object with quantityElectronic' do
       expect(orders_hash['compositePoLines'][0]['locations'][0]['quantityElectronic']).to eq 1
@@ -503,12 +501,12 @@ describe 'load SUL orders rake tasks' do
 
   context 'when order format is other' do
     let(:order_id) do
-      load_sul_orders_task.send(:get_id_data, YAML.load_file("#{sul_order_yaml_dir}/VENDOR_GBP-SH.yaml")).shift
+      transform_sul_orders_task.send(:get_id_data, YAML.load_file("#{sul_order_yaml_dir}/VENDOR_GBP-SH.yaml")).shift
     end
     let(:sym_order) do
-      load_sul_orders_task.send(:get_id_data, YAML.load_file("#{sul_order_yaml_dir}/VENDOR_GBP-SH.yaml")).pop
+      transform_sul_orders_task.send(:get_id_data, YAML.load_file("#{sul_order_yaml_dir}/VENDOR_GBP-SH.yaml")).pop
     end
-    let(:orders_hash) { load_sul_orders_task.send(:orders_hash, order_id, sym_order, acq_unit_uuid, uuid_hashes) }
+    let(:orders_hash) { transform_sul_orders_task.send(:orders_hash, order_id, sym_order, acq_unit_uuid, uuid_hashes) }
 
     it 'removes forward slashes and hyphens from poNumber' do
       expect(orders_hash['poNumber']).to eq 'VENDORGBPSH'
@@ -537,12 +535,12 @@ describe 'load SUL orders rake tasks' do
 
   context 'when order format is P/E Mix' do
     let(:order_id) do
-      load_sul_orders_task.send(:get_id_data, YAML.load_file("#{sul_order_yaml_dir}/777777F02.yaml")).shift
+      transform_sul_orders_task.send(:get_id_data, YAML.load_file("#{sul_order_yaml_dir}/777777F02.yaml")).shift
     end
     let(:sym_order) do
-      load_sul_orders_task.send(:get_id_data, YAML.load_file("#{sul_order_yaml_dir}/777777F02.yaml")).pop
+      transform_sul_orders_task.send(:get_id_data, YAML.load_file("#{sul_order_yaml_dir}/777777F02.yaml")).pop
     end
-    let(:orders_hash) { load_sul_orders_task.send(:orders_hash, order_id, sym_order, acq_unit_uuid, uuid_hashes) }
+    let(:orders_hash) { transform_sul_orders_task.send(:orders_hash, order_id, sym_order, acq_unit_uuid, uuid_hashes) }
 
     it 'has a locations object with quantityElectronic' do
       expect(orders_hash['compositePoLines'][0]['locations'][0]['quantityElectronic']).to eq 1
@@ -587,12 +585,12 @@ describe 'load SUL orders rake tasks' do
 
   context 'when vendor does not exist in Folio' do
     let(:order_id) do
-      load_sul_orders_task.send(:get_id_data, YAML.load_file("#{sul_order_yaml_dir}/555555F12.yaml")).shift
+      transform_sul_orders_task.send(:get_id_data, YAML.load_file("#{sul_order_yaml_dir}/555555F12.yaml")).shift
     end
     let(:sym_order) do
-      load_sul_orders_task.send(:get_id_data, YAML.load_file("#{sul_order_yaml_dir}/555555F12.yaml")).pop
+      transform_sul_orders_task.send(:get_id_data, YAML.load_file("#{sul_order_yaml_dir}/555555F12.yaml")).pop
     end
-    let(:orders_hash) { load_sul_orders_task.send(:orders_hash, order_id, sym_order, acq_unit_uuid, uuid_hashes) }
+    let(:orders_hash) { transform_sul_orders_task.send(:orders_hash, order_id, sym_order, acq_unit_uuid, uuid_hashes) }
 
     it 'has the correct vendor UUID' do
       expect(orders_hash['vendor']).to eq 'org-456'
@@ -601,12 +599,12 @@ describe 'load SUL orders rake tasks' do
 
   context 'when acquisition method does not exist in Folio' do
     let(:order_id) do
-      load_sul_orders_task.send(:get_id_data, YAML.load_file("#{sul_order_yaml_dir}/1ABC0000.yaml")).shift
+      transform_sul_orders_task.send(:get_id_data, YAML.load_file("#{sul_order_yaml_dir}/1ABC0000.yaml")).shift
     end
     let(:sym_order) do
-      load_sul_orders_task.send(:get_id_data, YAML.load_file("#{sul_order_yaml_dir}/1ABC0000.yaml")).pop
+      transform_sul_orders_task.send(:get_id_data, YAML.load_file("#{sul_order_yaml_dir}/1ABC0000.yaml")).pop
     end
-    let(:orders_hash) { load_sul_orders_task.send(:orders_hash, order_id, sym_order, acq_unit_uuid, uuid_hashes) }
+    let(:orders_hash) { transform_sul_orders_task.send(:orders_hash, order_id, sym_order, acq_unit_uuid, uuid_hashes) }
 
     it 'has the acquisitions method UUID for Other' do
       expect(orders_hash['compositePoLines'].sample['acquisitionMethod']).to eq 'acq-123'

--- a/spec/acquisitions/transform_sul_orders_task_spec.rb
+++ b/spec/acquisitions/transform_sul_orders_task_spec.rb
@@ -14,7 +14,7 @@ describe 'transform SUL orders rake tasks' do
     transform_sul_orders_task.send(:hldg_code_map, 'sym_hldg_code_location_map.tsv', Uuids.sul_locations)
   end
   let(:uuid_hashes) do
-    [Uuids.tenant_addresses, AcquisitionsUuidsHelpers.sul_organizations, order_type_map, hldg_code_map,
+    [acq_unit_uuid, Uuids.tenant_addresses, AcquisitionsUuidsHelpers.sul_organizations, order_type_map, hldg_code_map,
      AcquisitionsUuidsHelpers.sul_funds]
   end
   let(:sul_order_yaml_dir) { Settings.yaml.sul_orders.to_s }
@@ -84,7 +84,7 @@ describe 'transform SUL orders rake tasks' do
     let(:sym_order) do
       transform_sul_orders_task.send(:get_id_data, YAML.load_file("#{sul_order_yaml_dir}/222222F22.yaml")).pop
     end
-    let(:orders_hash) { transform_sul_orders_task.send(:orders_hash, order_id, sym_order, acq_unit_uuid, uuid_hashes) }
+    let(:orders_hash) { transform_sul_orders_task.send(:orders_hash, order_id, sym_order, uuid_hashes) }
 
     it 'has a UUID in the id field' do
       expect(orders_hash['id']).to eq '702e48f3-2931-5c47-9767-07211e561303'
@@ -154,7 +154,7 @@ describe 'transform SUL orders rake tasks' do
     let(:sym_order) do
       transform_sul_orders_task.send(:get_id_data, YAML.load_file("#{sul_order_yaml_dir}/444444F21.yaml")).pop
     end
-    let(:orders_hash) { transform_sul_orders_task.send(:orders_hash, order_id, sym_order, acq_unit_uuid, uuid_hashes) }
+    let(:orders_hash) { transform_sul_orders_task.send(:orders_hash, order_id, sym_order, uuid_hashes) }
 
     it 'has receipt status of Awaiting Receipt' do
       expect(orders_hash['compositePoLines'][0]['receiptStatus']).to eq 'Awaiting Receipt'
@@ -180,7 +180,7 @@ describe 'transform SUL orders rake tasks' do
     let(:sym_order) do
       transform_sul_orders_task.send(:get_id_data, YAML.load_file("#{sul_order_yaml_dir}/555555F12.yaml")).pop
     end
-    let(:orders_hash) { transform_sul_orders_task.send(:orders_hash, order_id, sym_order, acq_unit_uuid, uuid_hashes) }
+    let(:orders_hash) { transform_sul_orders_task.send(:orders_hash, order_id, sym_order, uuid_hashes) }
 
     it 'has isSubscription is true' do
       expect(orders_hash['ongoing']['isSubscription']).to be_truthy
@@ -226,7 +226,7 @@ describe 'transform SUL orders rake tasks' do
     let(:sym_order) do
       transform_sul_orders_task.send(:get_id_data, YAML.load_file("#{sul_order_yaml_dir}/1ABC0000.yaml")).pop
     end
-    let(:orders_hash) { transform_sul_orders_task.send(:orders_hash, order_id, sym_order, acq_unit_uuid, uuid_hashes) }
+    let(:orders_hash) { transform_sul_orders_task.send(:orders_hash, order_id, sym_order, uuid_hashes) }
 
     it 'has order type of ongoing' do
       expect(orders_hash['orderType']).to eq 'Ongoing'
@@ -276,7 +276,7 @@ describe 'transform SUL orders rake tasks' do
     let(:sym_order) do
       transform_sul_orders_task.send(:get_id_data, YAML.load_file("#{sul_order_yaml_dir}/333333F22.yaml")).pop
     end
-    let(:orders_hash) { transform_sul_orders_task.send(:orders_hash, order_id, sym_order, acq_unit_uuid, uuid_hashes) }
+    let(:orders_hash) { transform_sul_orders_task.send(:orders_hash, order_id, sym_order, uuid_hashes) }
     let(:po_line_fund_dist) { orders_hash['compositePoLines'][0]['fundDistribution'] }
 
     it 'has distribution type of amount' do
@@ -315,7 +315,7 @@ describe 'transform SUL orders rake tasks' do
     let(:sym_order) do
       transform_sul_orders_task.send(:get_id_data, YAML.load_file("#{sul_order_yaml_dir}/222222F22.yaml")).pop
     end
-    let(:orders_hash) { transform_sul_orders_task.send(:orders_hash, order_id, sym_order, acq_unit_uuid, uuid_hashes) }
+    let(:orders_hash) { transform_sul_orders_task.send(:orders_hash, order_id, sym_order, uuid_hashes) }
     let(:po_line_fund_dist) { orders_hash['compositePoLines'][0]['fundDistribution'] }
 
     it 'has distribution type of percentage' do
@@ -346,7 +346,7 @@ describe 'transform SUL orders rake tasks' do
     let(:sym_order) do
       transform_sul_orders_task.send(:get_id_data, YAML.load_file("#{sul_order_yaml_dir}/666666F07.yaml")).pop
     end
-    let(:orders_hash) { transform_sul_orders_task.send(:orders_hash, order_id, sym_order, acq_unit_uuid, uuid_hashes) }
+    let(:orders_hash) { transform_sul_orders_task.send(:orders_hash, order_id, sym_order, uuid_hashes) }
 
     it 'has order xinfo and orderline1 xinfo notes as list of notes' do
       expect(orders_hash['notes']).to be_kind_of Array
@@ -371,14 +371,14 @@ describe 'transform SUL orders rake tasks' do
     it 'does not have empty note fields' do
       order_id, sym_order = transform_sul_orders_task.send(:get_id_data,
                                                            YAML.load_file("#{sul_order_yaml_dir}/555555F12.yaml"))
-      order = transform_sul_orders_task.send(:orders_hash, order_id, sym_order, acq_unit_uuid, uuid_hashes)
+      order = transform_sul_orders_task.send(:orders_hash, order_id, sym_order, uuid_hashes)
       expect(order['notes']).not_to include 'COMMENT: '
     end
 
     it 'has FUND in the poLineDescription field' do
       order_id, sym_order = transform_sul_orders_task.send(:get_id_data,
                                                            YAML.load_file("#{sul_order_yaml_dir}/555555F12.yaml"))
-      order = transform_sul_orders_task.send(:orders_hash, order_id, sym_order, acq_unit_uuid, uuid_hashes)
+      order = transform_sul_orders_task.send(:orders_hash, order_id, sym_order, uuid_hashes)
       expect(order['compositePoLines'][0]['poLineDescription']).to eq 'FUND: ASULFUND 25%; ASULFUND 12%; ASULFUND 63%'
     end
   end
@@ -390,7 +390,7 @@ describe 'transform SUL orders rake tasks' do
     let(:sym_order) do
       transform_sul_orders_task.send(:get_id_data, YAML.load_file("#{sul_order_yaml_dir}/222222F22.yaml")).pop
     end
-    let(:orders_hash) { transform_sul_orders_task.send(:orders_hash, order_id, sym_order, acq_unit_uuid, uuid_hashes) }
+    let(:orders_hash) { transform_sul_orders_task.send(:orders_hash, order_id, sym_order, uuid_hashes) }
 
     it 'has a locations object with quantityPhysical' do
       expect(orders_hash['compositePoLines'][0]['locations'][0]['quantityPhysical']).to eq 1
@@ -444,7 +444,7 @@ describe 'transform SUL orders rake tasks' do
     let(:sym_order) do
       transform_sul_orders_task.send(:get_id_data, YAML.load_file("#{sul_order_yaml_dir}/666666F07.yaml")).pop
     end
-    let(:orders_hash) { transform_sul_orders_task.send(:orders_hash, order_id, sym_order, acq_unit_uuid, uuid_hashes) }
+    let(:orders_hash) { transform_sul_orders_task.send(:orders_hash, order_id, sym_order, uuid_hashes) }
 
     it 'has a locations object with quantityElectronic' do
       expect(orders_hash['compositePoLines'][0]['locations'][0]['quantityElectronic']).to eq 1
@@ -506,7 +506,7 @@ describe 'transform SUL orders rake tasks' do
     let(:sym_order) do
       transform_sul_orders_task.send(:get_id_data, YAML.load_file("#{sul_order_yaml_dir}/VENDOR_GBP-SH.yaml")).pop
     end
-    let(:orders_hash) { transform_sul_orders_task.send(:orders_hash, order_id, sym_order, acq_unit_uuid, uuid_hashes) }
+    let(:orders_hash) { transform_sul_orders_task.send(:orders_hash, order_id, sym_order, uuid_hashes) }
 
     it 'removes forward slashes and hyphens from poNumber' do
       expect(orders_hash['poNumber']).to eq 'VENDORGBPSH'
@@ -540,7 +540,7 @@ describe 'transform SUL orders rake tasks' do
     let(:sym_order) do
       transform_sul_orders_task.send(:get_id_data, YAML.load_file("#{sul_order_yaml_dir}/777777F02.yaml")).pop
     end
-    let(:orders_hash) { transform_sul_orders_task.send(:orders_hash, order_id, sym_order, acq_unit_uuid, uuid_hashes) }
+    let(:orders_hash) { transform_sul_orders_task.send(:orders_hash, order_id, sym_order, uuid_hashes) }
 
     it 'has a locations object with quantityElectronic' do
       expect(orders_hash['compositePoLines'][0]['locations'][0]['quantityElectronic']).to eq 1
@@ -590,7 +590,7 @@ describe 'transform SUL orders rake tasks' do
     let(:sym_order) do
       transform_sul_orders_task.send(:get_id_data, YAML.load_file("#{sul_order_yaml_dir}/555555F12.yaml")).pop
     end
-    let(:orders_hash) { transform_sul_orders_task.send(:orders_hash, order_id, sym_order, acq_unit_uuid, uuid_hashes) }
+    let(:orders_hash) { transform_sul_orders_task.send(:orders_hash, order_id, sym_order, uuid_hashes) }
 
     it 'has the correct vendor UUID' do
       expect(orders_hash['vendor']).to eq 'org-456'
@@ -604,7 +604,7 @@ describe 'transform SUL orders rake tasks' do
     let(:sym_order) do
       transform_sul_orders_task.send(:get_id_data, YAML.load_file("#{sul_order_yaml_dir}/1ABC0000.yaml")).pop
     end
-    let(:orders_hash) { transform_sul_orders_task.send(:orders_hash, order_id, sym_order, acq_unit_uuid, uuid_hashes) }
+    let(:orders_hash) { transform_sul_orders_task.send(:orders_hash, order_id, sym_order, uuid_hashes) }
 
     it 'has the acquisitions method UUID for Other' do
       expect(orders_hash['compositePoLines'].sample['acquisitionMethod']).to eq 'acq-123'

--- a/tasks/acquisitions/delete_orders.rake
+++ b/tasks/acquisitions/delete_orders.rake
@@ -3,16 +3,13 @@
 require 'require_all'
 require_rel '../helpers/orders'
 require_relative '../helpers/uuids/acquisitions'
+require_relative '../helpers/folio_jobs'
 
 namespace :acquisitions do
-  include AcquisitionsUuidsHelpers, OrdersTaskHelpers
+  include AcquisitionsUuidsHelpers, FolioJobs, OrdersTaskHelpers
 
-  desc 'delete all orders from folio'
-  task :delete_all_orders do
-    orders_hash = AcquisitionsUuidsHelpers.orders
-    orders_hash.each_value do |id|
-      puts "deleting order #{id}"
-      orders_delete(id)
-    end
+  desc 'multi-thread delete all orders from folio with pool size'
+  task :delete_all_orders, [:size] do |_, args|
+    batch_delete_orders(args[:size].to_i)
   end
 end

--- a/tasks/acquisitions/load_orders.rake
+++ b/tasks/acquisitions/load_orders.rake
@@ -1,55 +1,19 @@
 # frozen_string_literal: true
 
 require 'csv'
-require 'require_all'
-require_rel '../helpers/orders'
-require_rel '../helpers/uuids'
-require_relative '../../lib/folio_uuid'
+require_relative '../helpers/orders/orders'
+require_relative '../helpers/folio_jobs'
 
 namespace :acquisitions do
-  include OrdersTaskHelpers, PoLinesHelpers, OrderTypeHelpers, HoldingCodeHelpers, Uuids, AcquisitionsUuidsHelpers
+  include FolioJobs, OrdersTaskHelpers
 
-  desc 'load SUL orders into folio'
-  task :load_orders_sul do
-    acq_unit_uuid = AcquisitionsUuidsHelpers.acq_units.fetch('SUL', nil)
-    order_type_map = order_type_mapping('order_type_map.tsv', Uuids.material_types,
-                                        AcquisitionsUuidsHelpers.acquisition_methods)
-    hldg_code_loc_map = hldg_code_map('sym_hldg_code_location_map.tsv', Uuids.sul_locations)
-    uuid_hashes = [Uuids.tenant_addresses, AcquisitionsUuidsHelpers.sul_organizations, order_type_map,
-                   hldg_code_loc_map, AcquisitionsUuidsHelpers.sul_funds]
-    order_yaml_dir = Settings.yaml.sul_orders.to_s
-    order_json_dir = "#{Settings.json_orders}/sul"
-    Dir.each_child(order_yaml_dir) do |file|
-      order_id, sym_order = get_id_data(YAML.load_file("#{order_yaml_dir}/#{file}"))
-      folio_composite_orders = orders_hash(order_id, sym_order, acq_unit_uuid, uuid_hashes)
-      next if ENV['STAGE'].eql?('test') # so files are not written when running tests
-
-      File.open("#{order_json_dir}/#{file.tr('.yaml', '.json')}", 'w') do |f|
-        f.puts folio_composite_orders.to_json
-        f.puts orders_post(folio_composite_orders).to_json
-      end
-    end
+  desc 'multi-thread load SUL orders with pool size'
+  task :load_sul_orders, [:size] do |_, args|
+    batch_post_orders("#{Settings.json_orders}/sul", args[:size].to_i)
   end
 
-  desc 'load LAW orders into folio'
-  task :load_orders_law do
-    acq_unit_uuid = AcquisitionsUuidsHelpers.acq_units.fetch('Law', nil)
-    order_type_map = order_type_mapping('order_type_map.tsv', Uuids.material_types,
-                                        AcquisitionsUuidsHelpers.acquisition_methods)
-    hldg_code_loc_map = hldg_code_map('sym_hldg_code_location_map.tsv', Uuids.law_locations)
-    uuid_hashes = [Uuids.tenant_addresses, AcquisitionsUuidsHelpers.law_organizations, order_type_map,
-                   hldg_code_loc_map, AcquisitionsUuidsHelpers.law_funds]
-    order_yaml_dir = Settings.yaml.law_orders.to_s
-    order_json_dir = "#{Settings.json_orders}/law"
-    Dir.each_child(order_yaml_dir) do |file|
-      order_id, sym_order = get_id_data(YAML.load_file("#{order_yaml_dir}/#{file}"))
-      folio_composite_orders = orders_hash(order_id, sym_order, acq_unit_uuid, uuid_hashes)
-      next if ENV['STAGE'].eql?('test') # so files are not written when running tests
-
-      File.open("#{order_json_dir}/#{file.tr('.yaml', '.json')}", 'w') do |f|
-        f.puts folio_composite_orders.to_json
-        f.puts orders_post(folio_composite_orders).to_json
-      end
-    end
+  desc 'multi-thread load LAW orders with pool size'
+  task :load_law_orders, [:size] do |_, args|
+    batch_post_orders("#{Settings.json_orders}/law", args[:size].to_i)
   end
 end

--- a/tasks/acquisitions/process_symphony_orders.rake
+++ b/tasks/acquisitions/process_symphony_orders.rake
@@ -6,7 +6,7 @@ require_rel '../helpers/orders'
 namespace :acquisitions do
   include OrderYamlTaskHelpers
 
-  desc 'create SUL orders yaml files'
+  desc 'process Symphony orders for SUL'
   task :create_sul_orders_yaml do
     data_dir = Settings.yaml.sul_orders.to_s
     orders_tsv('orders_sul.tsv').each do |obj|
@@ -23,7 +23,7 @@ namespace :acquisitions do
   end
 
   desc 'add order xinfo fields to order yaml files'
-  task :add_sul_order_xinfo_to_yaml do
+  task :add_sul_order_xinfo do
     data_dir = Settings.yaml.sul_orders.to_s
     orders_tsv('order_xinfo_sul.tsv').each do |obj|
       filename = "#{data_dir}/#{obj['ORD_ID'].to_s.tr('/', '_')}.yaml"
@@ -37,7 +37,7 @@ namespace :acquisitions do
   end
 
   desc 'add orderline 1 xinfo fields to order yaml files'
-  task :add_sul_orderlin1_xinfo_to_yaml do
+  task :add_sul_orderlin1_xinfo do
     data_dir = Settings.yaml.sul_orders.to_s
     orders_tsv('orderlin1_xinfo_sul.tsv').each do |obj|
       filename = "#{data_dir}/#{obj['ORD_ID'].to_s.tr('/', '_')}.yaml"
@@ -51,7 +51,7 @@ namespace :acquisitions do
   end
 
   desc 'add orderline xinfo fields to order yaml files'
-  task :add_sul_orderline_xinfo_to_yaml do
+  task :add_sul_orderline_xinfo do
     data_dir = Settings.yaml.sul_orders.to_s
     orders_tsv('orderlin_xinfo_sul.tsv').each do |obj|
       filename = "#{data_dir}/#{obj['ORD_ID'].to_s.tr('/', '_')}.yaml"
@@ -64,7 +64,7 @@ namespace :acquisitions do
     end
   end
 
-  desc 'create LAW orders yaml files'
+  desc 'process Symphony orders for LAW'
   task :create_law_orders_yaml do
     data_dir = Settings.yaml.law_orders.to_s
     orders_tsv('orders_law.tsv').each do |obj|
@@ -82,7 +82,7 @@ namespace :acquisitions do
   end
 
   desc 'add order xinfo fields to order yaml files'
-  task :add_law_order_xinfo_to_yaml do
+  task :add_law_order_xinfo do
     data_dir = Settings.yaml.law_orders.to_s
     orders_tsv('order_xinfo_law.tsv').each do |obj|
       filename = "#{data_dir}/#{obj['ORD_ID'].to_s.tr('/', '_')}.yaml"
@@ -96,7 +96,7 @@ namespace :acquisitions do
   end
 
   desc 'add orderline 1 xinfo fields to order yaml files'
-  task :add_law_orderlin1_xinfo_to_yaml do
+  task :add_law_orderlin1_xinfo do
     data_dir = Settings.yaml.law_orders.to_s
     orders_tsv('orderlin1_xinfo_law.tsv').each do |obj|
       filename = "#{data_dir}/#{obj['ORD_ID'].to_s.tr('/', '_')}.yaml"
@@ -110,7 +110,7 @@ namespace :acquisitions do
   end
 
   desc 'add orderline xinfo fields to order yaml files'
-  task :add_law_orderline_xinfo_to_yaml do
+  task :add_law_orderline_xinfo do
     data_dir = Settings.yaml.law_orders.to_s
     orders_tsv('orderlin_xinfo_law.tsv').each do |obj|
       filename = "#{data_dir}/#{obj['ORD_ID'].to_s.tr('/', '_')}.yaml"

--- a/tasks/acquisitions/transform_to_folio_orders.rake
+++ b/tasks/acquisitions/transform_to_folio_orders.rake
@@ -50,4 +50,16 @@ namespace :acquisitions do
       end
     end
   end
+
+  desc 'delete sul folio order json files'
+  task :delete_sul_order_json do
+    data_dir = "#{Settings.json_orders}/sul"
+    Dir.each_child(data_dir) { |i| File.delete("#{data_dir}/#{i}") }
+  end
+
+  desc 'delete law folio order json files'
+  task :delete_law_order_json do
+    data_dir = "#{Settings.json_orders}/law"
+    Dir.each_child(data_dir) { |i| File.delete("#{data_dir}/#{i}") }
+  end
 end

--- a/tasks/acquisitions/transform_to_folio_orders.rake
+++ b/tasks/acquisitions/transform_to_folio_orders.rake
@@ -1,54 +1,19 @@
 # frozen_string_literal: true
 
 require 'csv'
-require 'require_all'
-require_rel '../helpers/orders'
-require_rel '../helpers/uuids'
-require_relative '../../lib/folio_uuid'
+require_relative '../helpers/orders/orders'
 
 namespace :acquisitions do
-  include OrdersTaskHelpers, PoLinesHelpers, OrderTypeHelpers, HoldingCodeHelpers, Uuids, AcquisitionsUuidsHelpers
+  include OrdersTaskHelpers
 
   desc 'transform SUL orders to folio orders'
   task :transform_sul_orders do
-    acq_unit_uuid = AcquisitionsUuidsHelpers.acq_units.fetch('SUL', nil)
-    order_type_map = order_type_mapping('order_type_map.tsv', Uuids.material_types,
-                                        AcquisitionsUuidsHelpers.acquisition_methods)
-    hldg_code_loc_map = hldg_code_map('sym_hldg_code_location_map.tsv', Uuids.sul_locations)
-    uuid_hashes = [Uuids.tenant_addresses, AcquisitionsUuidsHelpers.sul_organizations, order_type_map,
-                   hldg_code_loc_map, AcquisitionsUuidsHelpers.sul_funds]
-    order_yaml_dir = Settings.yaml.sul_orders.to_s
-    order_json_dir = "#{Settings.json_orders}/sul"
-    Dir.each_child(order_yaml_dir) do |file|
-      order_id, sym_order = get_id_data(YAML.load_file("#{order_yaml_dir}/#{file}"))
-      folio_composite_orders = orders_hash(order_id, sym_order, acq_unit_uuid, uuid_hashes)
-      next if ENV['STAGE'].eql?('test') # so files are not written when running tests
-
-      File.open("#{order_json_dir}/#{file.tr('.yaml', '.json')}", 'w') do |f|
-        f.puts folio_composite_orders.to_json
-      end
-    end
+    transform_sul_orders
   end
 
   desc 'transform LAW orders to folio orders'
   task :transform_law_orders do
-    acq_unit_uuid = AcquisitionsUuidsHelpers.acq_units.fetch('Law', nil)
-    order_type_map = order_type_mapping('order_type_map.tsv', Uuids.material_types,
-                                        AcquisitionsUuidsHelpers.acquisition_methods)
-    hldg_code_loc_map = hldg_code_map('sym_hldg_code_location_map.tsv', Uuids.law_locations)
-    uuid_hashes = [Uuids.tenant_addresses, AcquisitionsUuidsHelpers.law_organizations, order_type_map,
-                   hldg_code_loc_map, AcquisitionsUuidsHelpers.law_funds]
-    order_yaml_dir = Settings.yaml.law_orders.to_s
-    order_json_dir = "#{Settings.json_orders}/law"
-    Dir.each_child(order_yaml_dir) do |file|
-      order_id, sym_order = get_id_data(YAML.load_file("#{order_yaml_dir}/#{file}"))
-      folio_composite_orders = orders_hash(order_id, sym_order, acq_unit_uuid, uuid_hashes)
-      next if ENV['STAGE'].eql?('test') # so files are not written when running tests
-
-      File.open("#{order_json_dir}/#{file.tr('.yaml', '.json')}", 'w') do |f|
-        f.puts folio_composite_orders.to_json
-      end
-    end
+    transform_law_orders
   end
 
   desc 'delete sul folio order json files'

--- a/tasks/acquisitions/transform_to_folio_orders.rake
+++ b/tasks/acquisitions/transform_to_folio_orders.rake
@@ -1,10 +1,14 @@
 # frozen_string_literal: true
 
 require 'csv'
-require_relative '../helpers/orders/orders'
+require 'require_all'
+require_rel '../helpers/orders'
+require_rel '../helpers/uuids'
+require_relative '../../lib/folio_uuid'
 
 namespace :acquisitions do
-  include OrdersTaskHelpers
+  include AcquisitionsUuidsHelpers, FolioRequestHelper, HoldingCodeHelpers, OrdersTaskHelpers, OrderTypeHelpers,
+          PoLinesHelpers, Uuids
 
   desc 'transform SUL orders to folio orders'
   task :transform_sul_orders do

--- a/tasks/acquisitions/transform_to_folio_orders.rake
+++ b/tasks/acquisitions/transform_to_folio_orders.rake
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'csv'
+require 'require_all'
+require_rel '../helpers/orders'
+require_rel '../helpers/uuids'
+require_relative '../../lib/folio_uuid'
+
+namespace :acquisitions do
+  include OrdersTaskHelpers, PoLinesHelpers, OrderTypeHelpers, HoldingCodeHelpers, Uuids, AcquisitionsUuidsHelpers
+
+  desc 'transform SUL orders to folio orders'
+  task :transform_sul_orders do
+    acq_unit_uuid = AcquisitionsUuidsHelpers.acq_units.fetch('SUL', nil)
+    order_type_map = order_type_mapping('order_type_map.tsv', Uuids.material_types,
+                                        AcquisitionsUuidsHelpers.acquisition_methods)
+    hldg_code_loc_map = hldg_code_map('sym_hldg_code_location_map.tsv', Uuids.sul_locations)
+    uuid_hashes = [Uuids.tenant_addresses, AcquisitionsUuidsHelpers.sul_organizations, order_type_map,
+                   hldg_code_loc_map, AcquisitionsUuidsHelpers.sul_funds]
+    order_yaml_dir = Settings.yaml.sul_orders.to_s
+    order_json_dir = "#{Settings.json_orders}/sul"
+    Dir.each_child(order_yaml_dir) do |file|
+      order_id, sym_order = get_id_data(YAML.load_file("#{order_yaml_dir}/#{file}"))
+      folio_composite_orders = orders_hash(order_id, sym_order, acq_unit_uuid, uuid_hashes)
+      next if ENV['STAGE'].eql?('test') # so files are not written when running tests
+
+      File.open("#{order_json_dir}/#{file.tr('.yaml', '.json')}", 'w') do |f|
+        f.puts folio_composite_orders.to_json
+      end
+    end
+  end
+
+  desc 'transform LAW orders to folio orders'
+  task :transform_law_orders do
+    acq_unit_uuid = AcquisitionsUuidsHelpers.acq_units.fetch('Law', nil)
+    order_type_map = order_type_mapping('order_type_map.tsv', Uuids.material_types,
+                                        AcquisitionsUuidsHelpers.acquisition_methods)
+    hldg_code_loc_map = hldg_code_map('sym_hldg_code_location_map.tsv', Uuids.law_locations)
+    uuid_hashes = [Uuids.tenant_addresses, AcquisitionsUuidsHelpers.law_organizations, order_type_map,
+                   hldg_code_loc_map, AcquisitionsUuidsHelpers.law_funds]
+    order_yaml_dir = Settings.yaml.law_orders.to_s
+    order_json_dir = "#{Settings.json_orders}/law"
+    Dir.each_child(order_yaml_dir) do |file|
+      order_id, sym_order = get_id_data(YAML.load_file("#{order_yaml_dir}/#{file}"))
+      folio_composite_orders = orders_hash(order_id, sym_order, acq_unit_uuid, uuid_hashes)
+      next if ENV['STAGE'].eql?('test') # so files are not written when running tests
+
+      File.open("#{order_json_dir}/#{file.tr('.yaml', '.json')}", 'w') do |f|
+        f.puts folio_composite_orders.to_json
+      end
+    end
+  end
+end

--- a/tasks/helpers/folio_jobs.rb
+++ b/tasks/helpers/folio_jobs.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+# Class to multi-thread loading data to folio
+module FolioJobs
+  def batch_post_orders(file_dir, pool_size)
+    jobs = Queue.new
+    Dir.each_child(file_dir) { |file| jobs.push("#{file_dir}/#{file}") }
+    command = 'orders_post(JSON.parse(File.read(entity)))'
+    do_work(pool_size, jobs, command)
+  end
+
+  def batch_delete_orders(pool_size)
+    jobs = Queue.new
+    AcquisitionsUuidsHelpers.orders.each_value { |uuid| jobs.push(uuid) }
+    command = 'orders_delete(entity)'
+    do_work(pool_size, jobs, command)
+  end
+
+  def do_work(pool_size, jobs, command)
+    execute_threads(
+      Array.new(pool_size) do |n|
+        Thread.new do
+          while (entity = jobs.pop(true))
+            puts "worker #{n} processing entity #{entity}"
+            instance_eval(command)
+          end
+        rescue ThreadError => e
+          puts e unless jobs.empty?
+        end
+      end
+    )
+  end
+
+  def execute_threads(workers)
+    workers.map(&:join) # execute the threads
+    workers.each(&:exit) if workers.each(&:stop?) # kill threads when done
+  end
+end

--- a/tasks/helpers/orders/orders.rb
+++ b/tasks/helpers/orders/orders.rb
@@ -7,6 +7,7 @@ require_relative '../folio_request'
 require_relative '../../../lib/folio_uuid'
 
 # Module to encapsulate methods used by orders rake tasks
+# rubocop: disable Metrics/ModuleLength
 module OrdersTaskHelpers
   include AcquisitionsUuidsHelpers, FolioRequestHelper, HoldingCodeHelpers, OrderTypeHelpers,
           PoLinesHelpers, Uuids
@@ -23,7 +24,7 @@ module OrdersTaskHelpers
   end
 
   def transform_law_orders
-    law_uuids =  uuid_hashes('Law')
+    law_uuids = uuid_hashes('Law')
     Dir.each_child(Settings.yaml.law_orders.to_s) do |file|
       order_id, sym_order = get_id_data(YAML.load_file("#{Settings.yaml.law_orders}/#{file}"))
       folio_composite_orders = orders_hash(order_id, sym_order, law_uuids)
@@ -214,3 +215,4 @@ module OrdersTaskHelpers
     @@folio_request.delete("/orders/composite-orders/#{id}")
   end
 end
+# rubocop: enable Metrics/ModuleLength

--- a/tasks/helpers/orders/orders.rb
+++ b/tasks/helpers/orders/orders.rb
@@ -1,16 +1,11 @@
 # frozen_string_literal: true
 
-require 'require_all'
-require_rel '../uuids'
-require_rel '../orders'
 require_relative '../folio_request'
-require_relative '../../../lib/folio_uuid'
 
 # Module to encapsulate methods used by orders rake tasks
 # rubocop: disable Metrics/ModuleLength
 module OrdersTaskHelpers
-  include AcquisitionsUuidsHelpers, FolioRequestHelper, HoldingCodeHelpers, OrderTypeHelpers,
-          PoLinesHelpers, Uuids
+  include FolioRequestHelper
 
   def transform_sul_orders
     sul_uuids = uuid_hashes('SUL')

--- a/tasks/helpers/orders/orders.rb
+++ b/tasks/helpers/orders/orders.rb
@@ -1,17 +1,63 @@
 # frozen_string_literal: true
 
+require 'require_all'
+require_rel '../uuids'
+require_rel '../orders'
 require_relative '../folio_request'
+require_relative '../../../lib/folio_uuid'
 
 # Module to encapsulate methods used by orders rake tasks
 module OrdersTaskHelpers
-  include FolioRequestHelper
+  include AcquisitionsUuidsHelpers, FolioRequestHelper, HoldingCodeHelpers, OrderTypeHelpers,
+          PoLinesHelpers, Uuids
+
+  def transform_sul_orders
+    sul_uuids = uuid_hashes('SUL')
+    Dir.each_child(Settings.yaml.sul_orders.to_s) do |file|
+      order_id, sym_order = get_id_data(YAML.load_file("#{Settings.yaml.sul_orders}/#{file}"))
+      folio_composite_orders = orders_hash(order_id, sym_order, sul_uuids)
+      File.open("#{Settings.json_orders}/sul/#{file.tr('.yaml', '.json')}", 'w') do |f|
+        f.puts folio_composite_orders.to_json
+      end
+    end
+  end
+
+  def transform_law_orders
+    law_uuids =  uuid_hashes('Law')
+    Dir.each_child(Settings.yaml.law_orders.to_s) do |file|
+      order_id, sym_order = get_id_data(YAML.load_file("#{Settings.yaml.law_orders}/#{file}"))
+      folio_composite_orders = orders_hash(order_id, sym_order, law_uuids)
+      File.open("#{Settings.json_orders}/law/#{file.tr('.yaml', '.json')}", 'w') do |f|
+        f.puts folio_composite_orders.to_json
+      end
+    end
+  end
+
+  def acq_unit_uuid(lib)
+    acq_units.fetch(lib, nil)
+  end
+
+  def order_type_map
+    order_type_mapping('order_type_map.tsv', material_types, acquisition_methods)
+  end
+
+  def hldg_code_loc_map(lib)
+    uuids = lib == 'SUL' ? sul_locations : law_locations
+    hldg_code_map('sym_hldg_code_location_map.tsv', uuids)
+  end
+
+  def uuid_hashes(lib)
+    orgs = lib == 'SUL' ? sul_organizations : law_organizations
+    funds = lib == 'SUL' ? sul_funds : law_funds
+    [acq_unit_uuid(lib), tenant_addresses, orgs, order_type_map, hldg_code_loc_map(lib), funds]
+  end
 
   def get_id_data(yaml_hash)
     [yaml_hash.keys.first, yaml_hash.values.first]
   end
 
-  def orders_hash(order_id, sym_order, acq_unit_uuid, uuid_hashes)
-    addresses, organizations, order_type_map, hldg_code_loc_map, funds = uuid_hashes
+  def orders_hash(order_id, sym_order, uuid_hashes)
+    acq_unit_uuid, addresses, organizations, order_type_map, hldg_code_loc_map, funds = uuid_hashes
     composite_orders = {
       'id' => determine_order_uuid(cleanup_po_num(order_id), Settings.okapi.url.to_s),
       'approved' => true,


### PR DESCRIPTION
Closes #73 
- renames rake tasks and file that create Symphony order data yaml files (process_symphony_orders.rake)
- moves rake task to create FOLIO orders as json files to new rake file (transform_to_folio_orders.rake)
- adds a FolioJobs module task helper to multi-thread loads and deletes
- modifies load orders and delete orders tasks to use FolioJobs, passing pool_size as a rake task argument
- adds task to delete FOLIO order json files