### PR TITLE
Temporarily replace courtesy user email addess with fake

### DIFF
--- a/tasks/helpers/tsv_user.rb
+++ b/tasks/helpers/tsv_user.rb
@@ -128,7 +128,8 @@ module TsvUserTaskHelpers
     last = last_name(user['NAME'])
     first = first_name(user['NAME'])
     middle = middle_name(user['NAME'])
-    email = user['EMAIL']
+    # email = user['EMAIL']
+    email = 'foliotesting@lists,stanford.edu'
 
     personal['lastName'] = last unless last.nil?
     personal['firstName'] = first unless first.nil?

--- a/tasks/helpers/tsv_user.rb
+++ b/tasks/helpers/tsv_user.rb
@@ -128,15 +128,17 @@ module TsvUserTaskHelpers
     last = last_name(user['NAME'])
     first = first_name(user['NAME'])
     middle = middle_name(user['NAME'])
-    # email = user['EMAIL']
-    email = 'foliotesting@lists,stanford.edu'
 
     personal['lastName'] = last unless last.nil?
     personal['firstName'] = first unless first.nil?
     personal['middleName'] = middle unless middle.nil?
-    personal['email'] = email unless email.nil?
+    personal['email'] = email_address(user)
     personal['addresses'] = [address(user)] unless check_address(user)
     personal
+  end
+
+  def email_address(user)
+    Settings.user_email_override || user['EMAIL'] || ''
   end
 
   def remove_temp_keys(user)


### PR DESCRIPTION
I think this will be the easiest way to replace the courtesy user email addresses, and it's the same way we do it for regular users in the userload.