### PR TITLE
Make sure method name matches

### DIFF
--- a/lib/modules/patron_groups.rb
+++ b/lib/modules/patron_groups.rb
@@ -33,7 +33,7 @@ class PatronGroups
       )
   end
 
-  def undergrad
+  def undergraduate
     @aff['type'].start_with?('student') && affiliation_description.include?('undergraduate')
   end
 


### PR DESCRIPTION
The method name must match the patron group name exactly as it is in folio and in the config settings in order to work.