### PR TITLE
Receiving workflow is false for synchronized and true for independent.

### DIFF
--- a/spec/acquisitions/transform_law_orders_task_spec.rb
+++ b/spec/acquisitions/transform_law_orders_task_spec.rb
@@ -89,7 +89,7 @@ describe 'transform LAW orders rake tasks' do
     end
 
     it 'has receiving workflow box set to synchronized' do
-      expect(orders_hash['compositePoLines'].sample['checkinItems']).to be_truthy
+      expect(orders_hash['compositePoLines'].sample['checkinItems']).to be_falsey
     end
 
     it 'has a billTo address' do

--- a/spec/acquisitions/transform_sul_orders_task_spec.rb
+++ b/spec/acquisitions/transform_sul_orders_task_spec.rb
@@ -139,7 +139,7 @@ describe 'transform SUL orders rake tasks' do
     end
 
     it 'has receiving workflow box set to synchronized' do
-      expect(orders_hash['compositePoLines'].sample['checkinItems']).to be_truthy
+      expect(orders_hash['compositePoLines'].sample['checkinItems']).to be_falsey
     end
 
     it 'has an instanceId' do
@@ -169,7 +169,7 @@ describe 'transform SUL orders rake tasks' do
     end
 
     it 'has receiving workflow box set to synchronized' do
-      expect(orders_hash['compositePoLines'].sample['checkinItems']).to be_truthy
+      expect(orders_hash['compositePoLines'].sample['checkinItems']).to be_falsey
     end
 
     it 'has a title in titleOrPackage' do
@@ -215,7 +215,7 @@ describe 'transform SUL orders rake tasks' do
     end
 
     it 'has receiving workflow box set to independent' do
-      expect(orders_hash['compositePoLines'].sample['checkinItems']).to be_falsey
+      expect(orders_hash['compositePoLines'].sample['checkinItems']).to be_truthy
     end
 
     it 'has a title in titleOrPackage' do
@@ -261,7 +261,7 @@ describe 'transform SUL orders rake tasks' do
     end
 
     it 'has receiving workflow box set to independent' do
-      expect(orders_hash['compositePoLines'].sample['checkinItems']).to be_falsey
+      expect(orders_hash['compositePoLines'].sample['checkinItems']).to be_truthy
     end
 
     it 'po line 1 does not have a details object with receivingNote' do
@@ -312,7 +312,7 @@ describe 'transform SUL orders rake tasks' do
     end
 
     it 'has receiving workflow box set to independent' do
-      expect(orders_hash['compositePoLines'].sample['checkinItems']).to be_falsey
+      expect(orders_hash['compositePoLines'].sample['checkinItems']).to be_truthy
     end
 
     it 'does not have a poLineDescription field' do

--- a/spec/fixtures/acquisitions/orders/tsv/order_type_map.tsv
+++ b/spec/fixtures/acquisitions/orders/tsv/order_type_map.tsv
@@ -1,9 +1,9 @@
 Symph_order_type	orderType	acquisitionMethod	orderFormat	materialType	isSubscription	checkinItems
-ELEC2	Ongoing	Subscription	Electronic Resource	periodical	true	false
-FIRM	One-Time	Purchase	Physical Resource	book	false	true
-MEMBERSHIP	Ongoing	Membership	Physical Resource	periodical	true	false
-SHIPPING	Ongoing	Shipping	Other	unspecified	false	false
-SO-COMBO	Ongoing	Standing order	P/E Mix	book	false	false
-STANDING	Ongoing	Standing order	Physical Resource	book	false	false
-SUBSCRIPT	Ongoing	Subscription	Physical Resource	periodical	true	false
-TERMSET	Ongoing	Purchase	Physical Resource	book	false	false
+ELEC2	Ongoing	Subscription	Electronic Resource	periodical	true	true
+FIRM	One-Time	Purchase	Physical Resource	book	false	false
+MEMBERSHIP	Ongoing	Membership	Physical Resource	periodical	true	true
+SHIPPING	Ongoing	Shipping	Other	unspecified	false	true
+SO-COMBO	Ongoing	Standing order	P/E Mix	book	false	true
+STANDING	Ongoing	Standing order	Physical Resource	book	false	true
+SUBSCRIPT	Ongoing	Subscription	Physical Resource	periodical	true	true
+TERMSET	Ongoing	Purchase	Physical Resource	book	false	true

--- a/tasks/helpers/orders/order_types.rb
+++ b/tasks/helpers/orders/order_types.rb
@@ -65,6 +65,9 @@ module OrderTypeHelpers
   end
 
   def check_in_items?(field, map)
+    # Receiving workflow: Based on value of poline.checkinItems
+    # Synchronized = false
+    # Independent = true
     map.dig(field, 'checkinItems').eql?('true')
   end
 end


### PR DESCRIPTION
Documented on this page: https://wiki.folio.org/display/MM/Create+orders+by+importing+MARC+Bibliographic+Records (see "Receiving workflow" in the Question column).