### PR TITLE
Moves processed files when response is not null

### DIFF
--- a/tasks/helpers/orders/po_lines.rb
+++ b/tasks/helpers/orders/po_lines.rb
@@ -177,7 +177,7 @@ module PoLinesHelpers
         updated_po_line = update_po_line_create_inventory(po_line, holding_id)
         response = orders_storage_put_polines(updated_po_line['id'], updated_po_line)
       end
-      File.rename("#{dirpath}/#{file}", "#{new_dirpath}/#{file}") unless ENV['STAGE'].eql?('test') || response != 204
+      File.rename("#{dirpath}/#{file}", "#{new_dirpath}/#{file}") unless ENV['STAGE'].eql?('test') || !response.nil?
     end
   end
 


### PR DESCRIPTION
The response in FolioRequest could be a ruby Hash, a NilClass (for 204 success), or a JSON::ParserError, which gives us access to http status. But we can't check for [http status](https://www.rubydoc.info/gems/http/HTTP/Response/Status) when it is success because we get a ruby Hash on success.
```
  def parse(response)
    pp JSON.parse(response)
  rescue JSON::ParserError
    puts response
  end
```
So, when the response is not null, it is a success and the processed file should be moved, otherwise, we don't want to move the file (and when the code is running in the test env).