### PR TITLE
LocationId could be nil if reprocessing order files

### DIFF
--- a/tasks/helpers/orders/po_lines.rb
+++ b/tasks/helpers/orders/po_lines.rb
@@ -182,7 +182,8 @@ module PoLinesHelpers
   end
 
   def lookup_holdings(obj)
-    return nil if obj['locations'].nil?
+    # locations could be nil or locationId could be when reprocessing files that had locationId updated to holdingId
+    return nil if obj['locations'].nil? || obj['locations'][0]['locationId'].nil?
 
     instance_id = obj['instanceId']
     location_id = obj['locations'][0]['locationId']


### PR DESCRIPTION
While running the `acquisitions:link_polines_to_inventory[sul]` task, it would keep failing with `org.folio.cql2pgjson.exception.QueryValidationException: org.z3950.zing.cql.CQLParseException: expected index or term, got EOF`. I *think* it was because the locationId was already updated to a holdingId in the locations object for some po lines on an order but the file was not moved to the "processed files" directory because other po lines on the order failed to update. 