### PR TITLE
MARC mapping update

### DIFF
--- a/spec/fixtures/json/data_import/marc_bib_mappings.json
+++ b/spec/fixtures/json/data_import/marc_bib_mappings.json
@@ -1,6559 +1,9 @@
 {
-  "100": [
-    {
-      "entity": [
-        {
-          "target": "contributors.authorityId",
-          "subfield": [
-            "9"
-          ],
-          "description": "Authority ID that controlling the contributor",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_contributor_name_type_id",
-                  "parameter": {
-                    "name": "Personal name"
-                  }
-                }
-              ]
-            }
-          ],
-          "target": "contributors.contributorNameTypeId",
-          "subfield": [
-
-          ],
-          "description": "Type for Personal Name",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_contributor_type_id"
-                }
-              ]
-            }
-          ],
-          "target": "contributors.contributorTypeId",
-          "subfield": [
-            "4"
-          ],
-          "description": "Type of contributor",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_contributor_type_text"
-                }
-              ]
-            }
-          ],
-          "target": "contributors.contributorTypeText",
-          "subfield": [
-            "e"
-          ],
-          "description": "Contributor type free text",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "value": "true",
-              "conditions": [
-
-              ]
-            }
-          ],
-          "target": "contributors.primary",
-          "subfield": [
-
-          ],
-          "description": "Primary contributor",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "trim_period, trim"
-                }
-              ]
-            }
-          ],
-          "target": "contributors.name",
-          "subfield": [
-            "a",
-            "b",
-            "c",
-            "d",
-            "f",
-            "g",
-            "j",
-            "k",
-            "l",
-            "n",
-            "p",
-            "q",
-            "t",
-            "u"
-          ],
-          "description": "Personal Name",
-          "applyRulesOnConcatenatedData": true
-        }
-      ]
-    }
-  ],
-  "110": [
-    {
-      "entity": [
-        {
-          "target": "contributors.authorityId",
-          "subfield": [
-            "9"
-          ],
-          "description": "Authority ID that controlling the contributor",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_contributor_name_type_id",
-                  "parameter": {
-                    "name": "Corporate name"
-                  }
-                }
-              ]
-            }
-          ],
-          "target": "contributors.contributorNameTypeId",
-          "subfield": [
-
-          ],
-          "description": "Type for Corporate Name",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_contributor_type_text"
-                }
-              ]
-            }
-          ],
-          "target": "contributors.contributorTypeText",
-          "subfield": [
-            "e"
-          ],
-          "description": "Contributor type free text",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_contributor_type_id"
-                }
-              ]
-            }
-          ],
-          "target": "contributors.contributorTypeId",
-          "subfield": [
-            "4"
-          ],
-          "description": "Type of contributor",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "value": "true",
-              "conditions": [
-
-              ]
-            }
-          ],
-          "target": "contributors.primary",
-          "subfield": [
-
-          ],
-          "description": "Primary contributor",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "trim_period, trim"
-                }
-              ]
-            }
-          ],
-          "target": "contributors.name",
-          "subfield": [
-            "a",
-            "b",
-            "c",
-            "d",
-            "f",
-            "g",
-            "k",
-            "l",
-            "n",
-            "p",
-            "t",
-            "u"
-          ],
-          "description": "Corporate Name",
-          "applyRulesOnConcatenatedData": true
-        }
-      ]
-    }
-  ],
-  "111": [
-    {
-      "entity": [
-        {
-          "target": "contributors.authorityId",
-          "subfield": [
-            "9"
-          ],
-          "description": "Authority ID that controlling the contributor",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_contributor_name_type_id",
-                  "parameter": {
-                    "name": "Meeting name"
-                  }
-                }
-              ]
-            }
-          ],
-          "target": "contributors.contributorNameTypeId",
-          "subfield": [
-
-          ],
-          "description": "Type for Meeting Name",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_contributor_type_id"
-                }
-              ]
-            }
-          ],
-          "target": "contributors.contributorTypeId",
-          "subfield": [
-            "4"
-          ],
-          "description": "Type of contributor",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_contributor_type_text"
-                }
-              ]
-            }
-          ],
-          "target": "contributors.contributorTypeText",
-          "subfield": [
-            "j"
-          ],
-          "description": "Contributor type free text",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "value": "true",
-              "conditions": [
-
-              ]
-            }
-          ],
-          "target": "contributors.primary",
-          "subfield": [
-
-          ],
-          "description": "Primary contributor",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "trim_period, trim"
-                }
-              ]
-            }
-          ],
-          "target": "contributors.name",
-          "subfield": [
-            "a",
-            "b",
-            "c",
-            "d",
-            "f",
-            "g",
-            "k",
-            "l",
-            "n",
-            "p",
-            "t",
-            "u"
-          ],
-          "description": "Meeting Name",
-          "applyRulesOnConcatenatedData": true
-        }
-      ]
-    }
-  ],
-  "130": [
-    {
-      "entity": [
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_alternative_title_type_id",
-                  "parameter": {
-                    "name": "Uniform title"
-                  }
-                }
-              ]
-            }
-          ],
-          "target": "alternativeTitles.alternativeTitleTypeId",
-          "subfield": [
-            "a",
-            "n",
-            "p",
-            "d",
-            "f",
-            "g",
-            "h",
-            "k",
-            "l",
-            "m",
-            "o",
-            "r",
-            "s",
-            "t"
-          ],
-          "description": "Alternative Title id",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "remove_ending_punc, trim"
-                }
-              ]
-            }
-          ],
-          "target": "alternativeTitles.alternativeTitle",
-          "subfield": [
-            "a",
-            "n",
-            "p",
-            "d",
-            "f",
-            "g",
-            "h",
-            "k",
-            "l",
-            "m",
-            "o",
-            "r",
-            "s",
-            "t"
-          ],
-          "description": "Alternative Title",
-          "applyRulesOnConcatenatedData": true
-        }
-      ]
-    }
-  ],
-  "210": [
-    {
-      "entity": [
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_alternative_title_type_id",
-                  "parameter": {
-                    "name": "Abbreviated title"
-                  }
-                }
-              ]
-            }
-          ],
-          "target": "alternativeTitles.alternativeTitleTypeId",
-          "subfield": [
-            "a",
-            "b"
-          ],
-          "description": "Alternative Title id",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "remove_ending_punc, trim"
-                }
-              ]
-            }
-          ],
-          "target": "alternativeTitles.alternativeTitle",
-          "subfield": [
-            "a",
-            "b"
-          ],
-          "description": "Alternative Title",
-          "applyRulesOnConcatenatedData": true
-        }
-      ]
-    }
-  ],
-  "240": [
-    {
-      "entity": [
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_alternative_title_type_id",
-                  "parameter": {
-                    "name": "Uniform title"
-                  }
-                }
-              ]
-            }
-          ],
-          "target": "alternativeTitles.alternativeTitleTypeId",
-          "subfield": [
-            "a",
-            "n",
-            "p",
-            "d",
-            "f",
-            "g",
-            "h",
-            "k",
-            "l",
-            "m",
-            "o",
-            "r",
-            "s"
-          ],
-          "description": "Alternative Title id",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "remove_ending_punc, trim"
-                }
-              ]
-            }
-          ],
-          "target": "alternativeTitles.alternativeTitle",
-          "subfield": [
-            "a",
-            "n",
-            "p",
-            "d",
-            "f",
-            "g",
-            "h",
-            "k",
-            "l",
-            "m",
-            "o",
-            "r",
-            "s"
-          ],
-          "description": "Alternative Title",
-          "applyRulesOnConcatenatedData": true
-        }
-      ]
-    }
-  ],
-  "245": [
-    {
-      "target": "title",
-      "subfield": [
-        "a",
-        "n",
-        "p",
-        "b",
-        "c",
-        "f",
-        "g",
-        "h",
-        "k",
-        "s"
-      ],
-      "description": "Resource Title",
-      "applyRulesOnConcatenatedData": true
-    },
-    {
-      "rules": [
-        {
-          "conditions": [
-            {
-              "type": "remove_prefix_by_indicator, capitalize"
-            }
-          ]
-        }
-      ],
-      "target": "indexTitle",
-      "subfield": [
-        "a",
-        "n",
-        "p",
-        "b"
-      ],
-      "description": "Index title",
-      "applyRulesOnConcatenatedData": true
-    }
-  ],
-  "246": [
-    {
-      "entity": [
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_alternative_title_type_id",
-                  "parameter": {
-                    "name": "Variant title"
-                  }
-                }
-              ]
-            }
-          ],
-          "target": "alternativeTitles.alternativeTitleTypeId",
-          "subfield": [
-            "i",
-            "a",
-            "n",
-            "p",
-            "b",
-            "f",
-            "g",
-            "h",
-            "5"
-          ],
-          "description": "Alternative Title id",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "remove_ending_punc, trim"
-                }
-              ]
-            }
-          ],
-          "target": "alternativeTitles.alternativeTitle",
-          "subfield": [
-            "i",
-            "a",
-            "n",
-            "p",
-            "b",
-            "f",
-            "g",
-            "h",
-            "5"
-          ],
-          "description": "Alternative Title",
-          "applyRulesOnConcatenatedData": true
-        }
-      ]
-    }
-  ],
-  "247": [
-    {
-      "entity": [
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_alternative_title_type_id",
-                  "parameter": {
-                    "name": "Former title"
-                  }
-                }
-              ]
-            }
-          ],
-          "target": "alternativeTitles.alternativeTitleTypeId",
-          "subfield": [
-            "a",
-            "n",
-            "p",
-            "b",
-            "f",
-            "g",
-            "h",
-            "x"
-          ],
-          "description": "Alternative Title id",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "remove_ending_punc, trim"
-                }
-              ]
-            }
-          ],
-          "target": "alternativeTitles.alternativeTitle",
-          "subfield": [
-            "a",
-            "n",
-            "p",
-            "b",
-            "f",
-            "g",
-            "h",
-            "x"
-          ],
-          "description": "Former title",
-          "applyRulesOnConcatenatedData": true
-        }
-      ]
-    }
-  ],
-  "250": [
-    {
-      "rules": [
-        {
-          "conditions": [
-            {
-              "type": "remove_ending_punc, trim"
-            }
-          ]
-        }
-      ],
-      "target": "editions",
-      "subfield": [
-        "a",
-        "b"
-      ],
-      "description": "Edition",
-      "applyRulesOnConcatenatedData": true
-    }
-  ],
-  "254": [
-    {
-      "rules": [
-        {
-          "conditions": [
-            {
-              "type": "remove_ending_punc, trim"
-            }
-          ]
-        }
-      ],
-      "target": "editions",
-      "subfield": [
-        "a"
-      ],
-      "description": "Edition",
-      "applyRulesOnConcatenatedData": true
-    }
-  ],
-  "255": [
-    {
-      "entity": [
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_note_type_id",
-                  "parameter": {
-                    "name": "Cartographic Mathematical Data"
-                  }
-                }
-              ]
-            }
-          ],
-          "target": "notes.instanceNoteTypeId",
-          "subfield": [
-            "a",
-            "b",
-            "c",
-            "d",
-            "e",
-            "f",
-            "g"
-          ],
-          "description": "Instance note type id",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "trim_period"
-                }
-              ]
-            }
-          ],
-          "target": "notes.note",
-          "subfield": [
-            "a",
-            "b",
-            "c",
-            "d",
-            "e",
-            "f",
-            "g"
-          ],
-          "description": "Cartographic Mathematical Data",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "value": "false",
-              "conditions": [
-
-              ]
-            }
-          ],
-          "target": "notes.staffOnly",
-          "subfield": [
-            "a",
-            "b",
-            "c",
-            "d",
-            "e",
-            "f",
-            "g"
-          ],
-          "description": "If true, determines that the note should not be visible for others than staff"
-        }
-      ]
-    }
-  ],
-  "260": [
-    {
-      "rules": [
-        {
-          "conditions": [
-            {
-              "type": "remove_ending_punc, trim"
-            }
-          ]
-        }
-      ],
-      "target": "publication.place",
-      "subfield": [
-        "a"
-      ],
-      "description": "Place of publication",
-      "subFieldDelimiter": [
-        {
-          "value": " ; ",
-          "subfields": [
-            "a"
-          ]
-        }
-      ]
-    },
-    {
-      "rules": [
-        {
-          "conditions": [
-            {
-              "type": "remove_ending_punc, trim"
-            }
-          ]
-        }
-      ],
-      "target": "publication.publisher",
-      "subfield": [
-        "b"
-      ],
-      "subFieldDelimiter": [
-        {
-          "value": " ; ",
-          "subfields": [
-            "b"
-          ]
-        }
-      ]
-    },
-    {
-      "rules": [
-        {
-          "conditions": [
-            {
-              "type": "remove_ending_punc, trim, trim_period"
-            }
-          ]
-        }
-      ],
-      "target": "publication.dateOfPublication",
-      "subfield": [
-        "c"
-      ],
-      "subFieldDelimiter": [
-        {
-          "value": " ; ",
-          "subfields": [
-            "c"
-          ]
-        }
-      ]
-    }
-  ],
-  "264": [
-    {
-      "rules": [
-        {
-          "conditions": [
-            {
-              "type": "remove_ending_punc, trim"
-            }
-          ]
-        }
-      ],
-      "target": "publication.place",
-      "subfield": [
-        "a"
-      ],
-      "description": "Place of publication",
-      "subFieldDelimiter": [
-        {
-          "value": " ; ",
-          "subfields": [
-            "a"
-          ]
-        }
-      ]
-    },
-    {
-      "rules": [
-        {
-          "conditions": [
-            {
-              "type": "remove_ending_punc, trim"
-            }
-          ]
-        }
-      ],
-      "target": "publication.publisher",
-      "subfield": [
-        "b"
-      ],
-      "description": "Publisher of publication",
-      "subFieldDelimiter": [
-        {
-          "value": " ; ",
-          "subfields": [
-            "b"
-          ]
-        }
-      ]
-    },
-    {
-      "rules": [
-        {
-          "conditions": [
-            {
-              "type": "remove_ending_punc, trim, trim_period"
-            }
-          ]
-        }
-      ],
-      "target": "publication.dateOfPublication",
-      "subfield": [
-        "c"
-      ],
-      "description": "Date of publication",
-      "subFieldDelimiter": [
-        {
-          "value": " ; ",
-          "subfields": [
-            "c"
-          ]
-        }
-      ]
-    },
-    {
-      "rules": [
-        {
-          "conditions": [
-            {
-              "type": "set_publisher_role"
-            }
-          ]
-        }
-      ],
-      "target": "publication.role",
-      "subfield": [
-        "a",
-        "b",
-        "c"
-      ],
-      "description": "Role of publication, defined by 2nd indicator",
-      "applyRulesOnConcatenatedData": true
-    }
-  ],
-  "300": [
-    {
-      "target": "physicalDescriptions",
-      "subfield": [
-        "a",
-        "b",
-        "c",
-        "e",
-        "f",
-        "g",
-        "3"
-      ]
-    }
-  ],
-  "310": [
-    {
-      "rules": [
-        {
-          "conditions": [
-            {
-              "type": "trim_period"
-            }
-          ]
-        }
-      ],
-      "target": "publicationFrequency",
-      "subfield": [
-        "a",
-        "b"
-      ],
-      "description": "Publication frequency",
-      "applyRulesOnConcatenatedData": true
-    }
-  ],
-  "321": [
-    {
-      "rules": [
-        {
-          "conditions": [
-            {
-              "type": "trim_period"
-            }
-          ]
-        }
-      ],
-      "target": "publicationFrequency",
-      "subfield": [
-        "a",
-        "b"
-      ],
-      "description": "Publication frequency",
-      "applyRulesOnConcatenatedData": true
-    }
-  ],
-  "336": [
-    {
-      "rules": [
-        {
-          "conditions": [
-            {
-              "type": "set_instance_type_id",
-              "parameter": {
-                "unspecifiedInstanceTypeCode": "zzz"
-              }
-            }
-          ]
-        }
-      ],
-      "target": "instanceTypeId",
-      "subfield": [
-        "a",
-        "b"
-      ],
-      "description": "Instance type ID",
-      "subFieldDelimiter": [
-        {
-          "value": "~",
-          "subfields": [
-            "a",
-            "b"
-          ]
-        }
-      ],
-      "ignoreSubsequentFields": true,
-      "ignoreSubsequentSubfields": true,
-      "applyRulesOnConcatenatedData": true
-    }
-  ],
-  "338": [
-    {
-      "rules": [
-        {
-          "conditions": [
-            {
-              "type": "set_instance_format_id"
-            }
-          ]
-        }
-      ],
-      "target": "instanceFormatIds",
-      "subfield": [
-        "b"
-      ],
-      "description": "Instance Format ID",
-      "ignoreSubsequentSubfields": true
-    }
-  ],
-  "340": [
-    {
-      "target": "physicalDescriptions",
-      "subfield": [
-        "a",
-        "b",
-        "c",
-        "d",
-        "e",
-        "f",
-        "g",
-        "h",
-        "i",
-        "j",
-        "k",
-        "l",
-        "m",
-        "n",
-        "o",
-        "p",
-        "q",
-        "3"
-      ]
-    }
-  ],
-  "344": [
-    {
-      "target": "physicalDescriptions",
-      "subfield": [
-        "a",
-        "b",
-        "c",
-        "d",
-        "e",
-        "f",
-        "g",
-        "h",
-        "i",
-        "j",
-        "3"
-      ]
-    }
-  ],
-  "347": [
-    {
-      "target": "physicalDescriptions",
-      "subfield": [
-        "a",
-        "b",
-        "c",
-        "d",
-        "e",
-        "f",
-        "3"
-      ]
-    }
-  ],
-  "348": [
-    {
-      "target": "physicalDescriptions",
-      "subfield": [
-        "a",
-        "b",
-        "c",
-        "d",
-        "3"
-      ]
-    }
-  ],
-  "362": [
-    {
-      "rules": [
-        {
-          "conditions": [
-            {
-              "type": "trim_period"
-            }
-          ]
-        }
-      ],
-      "target": "publicationRange",
-      "subfield": [
-        "a",
-        "z"
-      ],
-      "description": "Publication range",
-      "applyRulesOnConcatenatedData": true
-    }
-  ],
-  "382": [
-    {
-      "entity": [
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_note_type_id",
-                  "parameter": {
-                    "name": "Music details note"
-                  }
-                }
-              ]
-            }
-          ],
-          "target": "notes.instanceNoteTypeId",
-          "subfield": [
-            "a",
-            "b",
-            "d",
-            "e",
-            "n",
-            "p",
-            "r",
-            "s",
-            "t",
-            "v",
-            "3"
-          ],
-          "description": "Instance note type id",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "trim_period"
-                }
-              ]
-            }
-          ],
-          "target": "notes.note",
-          "subfield": [
-            "a",
-            "b",
-            "d",
-            "e",
-            "n",
-            "p",
-            "r",
-            "s",
-            "t",
-            "v",
-            "3"
-          ],
-          "description": "Music details note",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "value": "false",
-              "conditions": [
-
-              ]
-            }
-          ],
-          "target": "notes.staffOnly",
-          "subfield": [
-            "a",
-            "b",
-            "d",
-            "e",
-            "n",
-            "p",
-            "r",
-            "s",
-            "t",
-            "v",
-            "3"
-          ],
-          "description": "If true, determines that the note should not be visible for others than staff"
-        }
-      ]
-    }
-  ],
-  "383": [
-    {
-      "entity": [
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_note_type_id",
-                  "parameter": {
-                    "name": "Music details note"
-                  }
-                }
-              ]
-            }
-          ],
-          "target": "notes.instanceNoteTypeId",
-          "subfield": [
-            "a",
-            "b",
-            "c",
-            "d",
-            "e",
-            "3"
-          ],
-          "description": "Instance note type id",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "trim_period"
-                }
-              ]
-            }
-          ],
-          "target": "notes.note",
-          "subfield": [
-            "a",
-            "b",
-            "c",
-            "d",
-            "e",
-            "3"
-          ],
-          "description": "Music details note",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "value": "false",
-              "conditions": [
-
-              ]
-            }
-          ],
-          "target": "notes.staffOnly",
-          "subfield": [
-            "a",
-            "b",
-            "c",
-            "d",
-            "e",
-            "3"
-          ],
-          "description": "If true, determines that the note should not be visible for others than staff"
-        }
-      ]
-    }
-  ],
-  "384": [
-    {
-      "entity": [
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_note_type_id",
-                  "parameter": {
-                    "name": "Music details note"
-                  }
-                }
-              ]
-            }
-          ],
-          "target": "notes.instanceNoteTypeId",
-          "subfield": [
-            "a",
-            "3"
-          ],
-          "description": "Instance note type id",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "trim_period"
-                }
-              ]
-            }
-          ],
-          "target": "notes.note",
-          "subfield": [
-            "a",
-            "3"
-          ],
-          "description": "Music details note",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "value": "false",
-              "conditions": [
-
-              ]
-            }
-          ],
-          "target": "notes.staffOnly",
-          "subfield": [
-            "a",
-            "3"
-          ],
-          "description": "If true, determines that the note should not be visible for others than staff"
-        }
-      ]
-    }
-  ],
-  "500": [
-    {
-      "entity": [
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_note_type_id",
-                  "parameter": {
-                    "name": "General note"
-                  }
-                }
-              ]
-            }
-          ],
-          "target": "notes.instanceNoteTypeId",
-          "subfield": [
-            "a",
-            "3",
-            "5"
-          ],
-          "description": "Instance note type id",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "trim_period"
-                }
-              ]
-            }
-          ],
-          "target": "notes.note",
-          "subfield": [
-            "a",
-            "3",
-            "5"
-          ],
-          "description": "General Note",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "value": "false",
-              "conditions": [
-
-              ]
-            }
-          ],
-          "target": "notes.staffOnly",
-          "subfield": [
-            "a",
-            "3",
-            "5"
-          ],
-          "description": "If true, determines that the note should not be visible for others than staff"
-        }
-      ]
-    }
-  ],
-  "501": [
-    {
-      "entity": [
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_note_type_id",
-                  "parameter": {
-                    "name": "With note"
-                  }
-                }
-              ]
-            }
-          ],
-          "target": "notes.instanceNoteTypeId",
-          "subfield": [
-            "a",
-            "5"
-          ],
-          "description": "Instance note type id",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "trim_period"
-                }
-              ]
-            }
-          ],
-          "target": "notes.note",
-          "subfield": [
-            "a",
-            "5"
-          ],
-          "description": "With Note",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "value": "false",
-              "conditions": [
-
-              ]
-            }
-          ],
-          "target": "notes.staffOnly",
-          "subfield": [
-            "a",
-            "5"
-          ],
-          "description": "If true, determines that the note should not be visible for others than staff"
-        }
-      ]
-    }
-  ],
-  "502": [
-    {
-      "entity": [
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_note_type_id",
-                  "parameter": {
-                    "name": "Dissertation note"
-                  }
-                }
-              ]
-            }
-          ],
-          "target": "notes.instanceNoteTypeId",
-          "subfield": [
-            "a",
-            "b",
-            "c",
-            "d",
-            "g",
-            "o"
-          ],
-          "description": "Instance note type id",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "trim_period"
-                }
-              ]
-            }
-          ],
-          "target": "notes.note",
-          "subfield": [
-            "a",
-            "b",
-            "c",
-            "d",
-            "g",
-            "o"
-          ],
-          "description": "Dissertation Note",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "value": "false",
-              "conditions": [
-
-              ]
-            }
-          ],
-          "target": "notes.staffOnly",
-          "subfield": [
-            "a",
-            "b",
-            "c",
-            "d",
-            "g",
-            "o"
-          ],
-          "description": "If true, determines that the note should not be visible for others than staff"
-        }
-      ]
-    }
-  ],
-  "504": [
-    {
-      "entity": [
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_note_type_id",
-                  "parameter": {
-                    "name": "Bibliography note"
-                  }
-                }
-              ]
-            }
-          ],
-          "target": "notes.instanceNoteTypeId",
-          "subfield": [
-            "a",
-            "b"
-          ],
-          "description": "Instance note type id",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "trim_period"
-                }
-              ]
-            }
-          ],
-          "target": "notes.note",
-          "subfield": [
-            "a",
-            "b"
-          ],
-          "description": "Bibliography, etc. Note",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "value": "false",
-              "conditions": [
-
-              ]
-            }
-          ],
-          "target": "notes.staffOnly",
-          "subfield": [
-            "a",
-            "b"
-          ],
-          "description": "If true, determines that the note should not be visible for others than staff"
-        }
-      ]
-    }
-  ],
-  "505": [
-    {
-      "entity": [
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_note_type_id",
-                  "parameter": {
-                    "name": "Formatted Contents Note"
-                  }
-                }
-              ]
-            }
-          ],
-          "target": "notes.instanceNoteTypeId",
-          "subfield": [
-            "a",
-            "g",
-            "r",
-            "t",
-            "u"
-          ],
-          "description": "Instance note type id",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "trim_period"
-                }
-              ]
-            }
-          ],
-          "target": "notes.note",
-          "subfield": [
-            "a",
-            "g",
-            "r",
-            "t",
-            "u"
-          ],
-          "description": "Formatted Contents Note",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "value": "false",
-              "conditions": [
-
-              ]
-            }
-          ],
-          "target": "notes.staffOnly",
-          "subfield": [
-            "a",
-            "g",
-            "r",
-            "t",
-            "u"
-          ],
-          "description": "If true, determines that the note should not be visible for others than staff"
-        }
-      ]
-    }
-  ],
-  "506": [
-    {
-      "entity": [
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_note_type_id",
-                  "parameter": {
-                    "name": "Restrictions on Access note"
-                  }
-                }
-              ]
-            }
-          ],
-          "target": "notes.instanceNoteTypeId",
-          "subfield": [
-            "a",
-            "b",
-            "c",
-            "d",
-            "e",
-            "f",
-            "u",
-            "2",
-            "3",
-            "5"
-          ],
-          "description": "Instance note type id",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "trim_period"
-                }
-              ]
-            }
-          ],
-          "target": "notes.note",
-          "subfield": [
-            "a",
-            "b",
-            "c",
-            "d",
-            "e",
-            "f",
-            "u",
-            "2",
-            "3",
-            "5"
-          ],
-          "description": "Restrictions on Access Note",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "value": "false",
-              "conditions": [
-
-              ]
-            }
-          ],
-          "target": "notes.staffOnly",
-          "subfield": [
-            "a",
-            "b",
-            "c",
-            "d",
-            "e",
-            "f",
-            "u",
-            "2",
-            "3",
-            "5"
-          ],
-          "description": "If true, determines that the note should not be visible for others than staff"
-        }
-      ]
-    }
-  ],
-  "507": [
-    {
-      "entity": [
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_note_type_id",
-                  "parameter": {
-                    "name": "Scale note for graphic material"
-                  }
-                }
-              ]
-            }
-          ],
-          "target": "notes.instanceNoteTypeId",
-          "subfield": [
-            "a",
-            "b"
-          ],
-          "description": "Instance note type id",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "trim_period"
-                }
-              ]
-            }
-          ],
-          "target": "notes.note",
-          "subfield": [
-            "a",
-            "b"
-          ],
-          "description": "Scale Note for Graphic Material",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "value": "false",
-              "conditions": [
-
-              ]
-            }
-          ],
-          "target": "notes.staffOnly",
-          "subfield": [
-            "a",
-            "b"
-          ],
-          "description": "If true, determines that the note should not be visible for others than staff"
-        }
-      ]
-    }
-  ],
-  "508": [
-    {
-      "entity": [
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_note_type_id",
-                  "parameter": {
-                    "name": "Creation / Production Credits note"
-                  }
-                }
-              ]
-            }
-          ],
-          "target": "notes.instanceNoteTypeId",
-          "subfield": [
-            "a"
-          ],
-          "description": "Instance note type id",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "trim_period"
-                }
-              ]
-            }
-          ],
-          "target": "notes.note",
-          "subfield": [
-            "a"
-          ],
-          "description": "Creation/Production Credits Note",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "value": "false",
-              "conditions": [
-
-              ]
-            }
-          ],
-          "target": "notes.staffOnly",
-          "subfield": [
-            "a"
-          ],
-          "description": "If true, determines that the note should not be visible for others than staff"
-        }
-      ]
-    }
-  ],
-  "510": [
-    {
-      "entity": [
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_note_type_id",
-                  "parameter": {
-                    "name": "Citation / References note"
-                  }
-                }
-              ]
-            }
-          ],
-          "target": "notes.instanceNoteTypeId",
-          "subfield": [
-            "a",
-            "b",
-            "c",
-            "u",
-            "x",
-            "3"
-          ],
-          "description": "Instance note type id",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "trim_period"
-                }
-              ]
-            }
-          ],
-          "target": "notes.note",
-          "subfield": [
-            "a",
-            "b",
-            "c",
-            "u",
-            "x",
-            "3"
-          ],
-          "description": "Citation/References Note",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "value": "false",
-              "conditions": [
-
-              ]
-            }
-          ],
-          "target": "notes.staffOnly",
-          "subfield": [
-            "a",
-            "b",
-            "c",
-            "u",
-            "x",
-            "3"
-          ],
-          "description": "If true, determines that the note should not be visible for others than staff"
-        }
-      ]
-    }
-  ],
-  "511": [
-    {
-      "entity": [
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_note_type_id",
-                  "parameter": {
-                    "name": "Participant or Performer note"
-                  }
-                }
-              ]
-            }
-          ],
-          "target": "notes.instanceNoteTypeId",
-          "subfield": [
-            "a"
-          ],
-          "description": "Instance note type id",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "trim_period"
-                }
-              ]
-            }
-          ],
-          "target": "notes.note",
-          "subfield": [
-            "a"
-          ],
-          "description": "Participant or Performer Note",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "value": "false",
-              "conditions": [
-
-              ]
-            }
-          ],
-          "target": "notes.staffOnly",
-          "subfield": [
-            "a"
-          ],
-          "description": "If true, determines that the note should not be visible for others than staff"
-        }
-      ]
-    }
-  ],
-  "513": [
-    {
-      "entity": [
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_note_type_id",
-                  "parameter": {
-                    "name": "Type of report and period covered note"
-                  }
-                }
-              ]
-            }
-          ],
-          "target": "notes.instanceNoteTypeId",
-          "subfield": [
-            "a",
-            "b"
-          ],
-          "description": "Instance note type id",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "trim_period"
-                }
-              ]
-            }
-          ],
-          "target": "notes.note",
-          "subfield": [
-            "a",
-            "b"
-          ],
-          "description": "Type of Report and Period Covered Note",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "value": "false",
-              "conditions": [
-
-              ]
-            }
-          ],
-          "target": "notes.staffOnly",
-          "subfield": [
-            "a",
-            "b"
-          ],
-          "description": "If true, determines that the note should not be visible for others than staff"
-        }
-      ]
-    }
-  ],
-  "514": [
-    {
-      "entity": [
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_note_type_id",
-                  "parameter": {
-                    "name": "Data quality note"
-                  }
-                }
-              ]
-            }
-          ],
-          "target": "notes.instanceNoteTypeId",
-          "subfield": [
-            "a",
-            "b",
-            "c",
-            "d",
-            "e",
-            "f",
-            "g",
-            "h",
-            "i",
-            "j",
-            "k",
-            "m",
-            "u",
-            "z"
-          ],
-          "description": "Instance note type id",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "trim_period"
-                }
-              ]
-            }
-          ],
-          "target": "notes.note",
-          "subfield": [
-            "a",
-            "b",
-            "c",
-            "d",
-            "e",
-            "f",
-            "g",
-            "h",
-            "i",
-            "j",
-            "k",
-            "m",
-            "u",
-            "z"
-          ],
-          "description": "Data Quality Note",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "value": "false",
-              "conditions": [
-
-              ]
-            }
-          ],
-          "target": "notes.staffOnly",
-          "subfield": [
-            "a",
-            "b",
-            "c",
-            "d",
-            "e",
-            "f",
-            "g",
-            "h",
-            "i",
-            "j",
-            "k",
-            "m",
-            "u",
-            "z"
-          ],
-          "description": "If true, determines that the note should not be visible for others than staff"
-        }
-      ]
-    }
-  ],
-  "515": [
-    {
-      "entity": [
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_note_type_id",
-                  "parameter": {
-                    "name": "Numbering peculiarities note"
-                  }
-                }
-              ]
-            }
-          ],
-          "target": "notes.instanceNoteTypeId",
-          "subfield": [
-            "a"
-          ],
-          "description": "Instance note type id",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "trim_period"
-                }
-              ]
-            }
-          ],
-          "target": "notes.note",
-          "subfield": [
-            "a"
-          ],
-          "description": "Numbering Peculiarities Note",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "value": "false",
-              "conditions": [
-
-              ]
-            }
-          ],
-          "target": "notes.staffOnly",
-          "subfield": [
-            "a"
-          ],
-          "description": "If true, determines that the note should not be visible for others than staff"
-        }
-      ]
-    }
-  ],
-  "516": [
-    {
-      "entity": [
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_note_type_id",
-                  "parameter": {
-                    "name": "Type of computer file or data note"
-                  }
-                }
-              ]
-            }
-          ],
-          "target": "notes.instanceNoteTypeId",
-          "subfield": [
-            "a"
-          ],
-          "description": "Instance note type id",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "trim_period"
-                }
-              ]
-            }
-          ],
-          "target": "notes.note",
-          "subfield": [
-            "a"
-          ],
-          "description": "Type of Computer File or Data Note",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "value": "false",
-              "conditions": [
-
-              ]
-            }
-          ],
-          "target": "notes.staffOnly",
-          "subfield": [
-            "a"
-          ],
-          "description": "If true, determines that the note should not be visible for others than staff"
-        }
-      ]
-    }
-  ],
-  "518": [
-    {
-      "entity": [
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_note_type_id",
-                  "parameter": {
-                    "name": "Date / time and place of an event note"
-                  }
-                }
-              ]
-            }
-          ],
-          "target": "notes.instanceNoteTypeId",
-          "subfield": [
-            "a",
-            "d",
-            "o",
-            "p",
-            "2",
-            "3"
-          ],
-          "description": "Instance note type id",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "trim_period"
-                }
-              ]
-            }
-          ],
-          "target": "notes.note",
-          "subfield": [
-            "a",
-            "d",
-            "o",
-            "p",
-            "2",
-            "3"
-          ],
-          "description": "Date/Time and Place of an Event Note",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "value": "false",
-              "conditions": [
-
-              ]
-            }
-          ],
-          "target": "notes.staffOnly",
-          "subfield": [
-            "a",
-            "d",
-            "o",
-            "p",
-            "2",
-            "3"
-          ],
-          "description": "If true, determines that the note should not be visible for others than staff"
-        }
-      ]
-    }
-  ],
-  "520": [
-    {
-      "entity": [
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_note_type_id",
-                  "parameter": {
-                    "name": "Summary"
-                  }
-                }
-              ]
-            }
-          ],
-          "target": "notes.instanceNoteTypeId",
-          "subfield": [
-            "a",
-            "b",
-            "c",
-            "u",
-            "2",
-            "3"
-          ],
-          "description": "Instance note type id",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "trim_period"
-                }
-              ]
-            }
-          ],
-          "target": "notes.note",
-          "subfield": [
-            "a",
-            "b",
-            "c",
-            "u",
-            "2",
-            "3"
-          ],
-          "description": "Summary, Etc.",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "value": "false",
-              "conditions": [
-
-              ]
-            }
-          ],
-          "target": "notes.staffOnly",
-          "subfield": [
-            "a",
-            "b",
-            "c",
-            "u",
-            "2",
-            "3"
-          ],
-          "description": "If true, determines that the note should not be visible for others than staff"
-        }
-      ]
-    }
-  ],
-  "521": [
-    {
-      "entity": [
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_note_type_id",
-                  "parameter": {
-                    "name": "Target Audience note"
-                  }
-                }
-              ]
-            }
-          ],
-          "target": "notes.instanceNoteTypeId",
-          "subfield": [
-            "a",
-            "b",
-            "3"
-          ],
-          "description": "Instance note type id",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "trim_period"
-                }
-              ]
-            }
-          ],
-          "target": "notes.note",
-          "subfield": [
-            "a",
-            "b",
-            "3"
-          ],
-          "description": "Target Audience Note",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "value": "false",
-              "conditions": [
-
-              ]
-            }
-          ],
-          "target": "notes.staffOnly",
-          "subfield": [
-            "a",
-            "b",
-            "3"
-          ],
-          "description": "If true, determines that the note should not be visible for others than staff"
-        }
-      ]
-    }
-  ],
-  "522": [
-    {
-      "entity": [
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_note_type_id",
-                  "parameter": {
-                    "name": "Geographic Coverage note"
-                  }
-                }
-              ]
-            }
-          ],
-          "target": "notes.instanceNoteTypeId",
-          "subfield": [
-            "a"
-          ],
-          "description": "Instance note type id",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "trim_period"
-                }
-              ]
-            }
-          ],
-          "target": "notes.note",
-          "subfield": [
-            "a"
-          ],
-          "description": "Geographic Coverage Note",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "value": "false",
-              "conditions": [
-
-              ]
-            }
-          ],
-          "target": "notes.staffOnly",
-          "subfield": [
-            "a"
-          ],
-          "description": "If true, determines that the note should not be visible for others than staff"
-        }
-      ]
-    }
-  ],
-  "524": [
-    {
-      "entity": [
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_note_type_id",
-                  "parameter": {
-                    "name": "Preferred Citation of Described Materials note"
-                  }
-                }
-              ]
-            }
-          ],
-          "target": "notes.instanceNoteTypeId",
-          "subfield": [
-            "a",
-            "2",
-            "3"
-          ],
-          "description": "Instance note type id",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "trim_period"
-                }
-              ]
-            }
-          ],
-          "target": "notes.note",
-          "subfield": [
-            "a",
-            "2",
-            "3"
-          ],
-          "description": "Preferred Citation of Described Materials Note",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "value": "false",
-              "conditions": [
-
-              ]
-            }
-          ],
-          "target": "notes.staffOnly",
-          "subfield": [
-            "a",
-            "2",
-            "3"
-          ],
-          "description": "If true, determines that the note should not be visible for others than staff"
-        }
-      ]
-    }
-  ],
-  "525": [
-    {
-      "entity": [
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_note_type_id",
-                  "parameter": {
-                    "name": "Supplement note"
-                  }
-                }
-              ]
-            }
-          ],
-          "target": "notes.instanceNoteTypeId",
-          "subfield": [
-            "a"
-          ],
-          "description": "Instance note type id",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "trim_period"
-                }
-              ]
-            }
-          ],
-          "target": "notes.note",
-          "subfield": [
-            "a"
-          ],
-          "description": "Supplement Note",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "value": "false",
-              "conditions": [
-
-              ]
-            }
-          ],
-          "target": "notes.staffOnly",
-          "subfield": [
-            "a"
-          ],
-          "description": "If true, determines that the note should not be visible for others than staff"
-        }
-      ]
-    }
-  ],
-  "526": [
-    {
-      "entity": [
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_note_type_id",
-                  "parameter": {
-                    "name": "Study Program Information note"
-                  }
-                }
-              ]
-            }
-          ],
-          "target": "notes.instanceNoteTypeId",
-          "subfield": [
-            "a",
-            "b",
-            "c",
-            "d",
-            "5",
-            "x",
-            "z"
-          ],
-          "description": "Instance note type id",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "trim_period"
-                }
-              ]
-            }
-          ],
-          "target": "notes.note",
-          "subfield": [
-            "a",
-            "b",
-            "c",
-            "d",
-            "5",
-            "x",
-            "z"
-          ],
-          "description": "Study Program Information Note",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "value": "false",
-              "conditions": [
-
-              ]
-            }
-          ],
-          "target": "notes.staffOnly",
-          "subfield": [
-            "a",
-            "b",
-            "c",
-            "d",
-            "5",
-            "x",
-            "z"
-          ],
-          "description": "If true, determines that the note should not be visible for others than staff"
-        }
-      ]
-    }
-  ],
-  "530": [
-    {
-      "entity": [
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_note_type_id",
-                  "parameter": {
-                    "name": "Additional Physical Form Available note"
-                  }
-                }
-              ]
-            }
-          ],
-          "target": "notes.instanceNoteTypeId",
-          "subfield": [
-            "a",
-            "b",
-            "c",
-            "d",
-            "u",
-            "3"
-          ],
-          "description": "Instance note type id",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "trim_period"
-                }
-              ]
-            }
-          ],
-          "target": "notes.note",
-          "subfield": [
-            "a",
-            "b",
-            "c",
-            "d",
-            "u",
-            "3"
-          ],
-          "description": "Additional Physical Form Available Note",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "value": "false",
-              "conditions": [
-
-              ]
-            }
-          ],
-          "target": "notes.staffOnly",
-          "subfield": [
-            "a",
-            "b",
-            "c",
-            "d",
-            "u",
-            "3"
-          ],
-          "description": "If true, determines that the note should not be visible for others than staff"
-        }
-      ]
-    }
-  ],
-  "532": [
-    {
-      "entity": [
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_note_type_id",
-                  "parameter": {
-                    "name": "Accessibility note"
-                  }
-                }
-              ]
-            }
-          ],
-          "target": "notes.instanceNoteTypeId",
-          "subfield": [
-            "a"
-          ],
-          "description": "Instance note type id",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "trim_period"
-                }
-              ]
-            }
-          ],
-          "target": "notes.note",
-          "subfield": [
-            "a"
-          ],
-          "description": "Accessibility note",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "value": "false",
-              "conditions": [
-
-              ]
-            }
-          ],
-          "target": "notes.staffOnly",
-          "subfield": [
-            "a"
-          ],
-          "description": "If true, determines that the note should not be visible for others than staff"
-        }
-      ]
-    }
-  ],
-  "533": [
-    {
-      "entity": [
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_note_type_id",
-                  "parameter": {
-                    "name": "Reproduction note"
-                  }
-                }
-              ]
-            }
-          ],
-          "target": "notes.instanceNoteTypeId",
-          "subfield": [
-            "a",
-            "b",
-            "c",
-            "d",
-            "e",
-            "f",
-            "m",
-            "n",
-            "3",
-            "5"
-          ],
-          "description": "Instance note type id",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "trim_period"
-                }
-              ]
-            }
-          ],
-          "target": "notes.note",
-          "subfield": [
-            "a",
-            "b",
-            "c",
-            "d",
-            "e",
-            "f",
-            "m",
-            "n",
-            "3",
-            "5"
-          ],
-          "description": "Reproduction Note",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "value": "false",
-              "conditions": [
-
-              ]
-            }
-          ],
-          "target": "notes.staffOnly",
-          "subfield": [
-            "a",
-            "b",
-            "c",
-            "d",
-            "e",
-            "f",
-            "m",
-            "n",
-            "3",
-            "5"
-          ],
-          "description": "If true, determines that the note should not be visible for others than staff"
-        }
-      ]
-    }
-  ],
-  "534": [
-    {
-      "entity": [
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_note_type_id",
-                  "parameter": {
-                    "name": "Original Version note"
-                  }
-                }
-              ]
-            }
-          ],
-          "target": "notes.instanceNoteTypeId",
-          "subfield": [
-            "a",
-            "b",
-            "c",
-            "e",
-            "f",
-            "k",
-            "l",
-            "m",
-            "n",
-            "o",
-            "p",
-            "t",
-            "x",
-            "z",
-            "3"
-          ],
-          "description": "Instance note type id",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "trim_period"
-                }
-              ]
-            }
-          ],
-          "target": "notes.note",
-          "subfield": [
-            "a",
-            "b",
-            "c",
-            "e",
-            "f",
-            "k",
-            "l",
-            "m",
-            "n",
-            "o",
-            "p",
-            "t",
-            "x",
-            "z",
-            "3"
-          ],
-          "description": "Original Version Note",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "value": "false",
-              "conditions": [
-
-              ]
-            }
-          ],
-          "target": "notes.staffOnly",
-          "subfield": [
-            "a",
-            "b",
-            "c",
-            "e",
-            "f",
-            "k",
-            "l",
-            "m",
-            "n",
-            "o",
-            "p",
-            "t",
-            "x",
-            "z",
-            "3"
-          ],
-          "description": "If true, determines that the note should not be visible for others than staff"
-        }
-      ]
-    }
-  ],
-  "535": [
-    {
-      "entity": [
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_note_type_id",
-                  "parameter": {
-                    "name": "Location of Originals / Duplicates note"
-                  }
-                }
-              ]
-            }
-          ],
-          "target": "notes.instanceNoteTypeId",
-          "subfield": [
-            "a",
-            "b",
-            "c",
-            "d",
-            "g",
-            "3"
-          ],
-          "description": "Instance note type id",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "trim_period"
-                }
-              ]
-            }
-          ],
-          "target": "notes.note",
-          "subfield": [
-            "a",
-            "b",
-            "c",
-            "d",
-            "g",
-            "3"
-          ],
-          "description": "Location of Originals/Duplicates Note",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "value": "false",
-              "conditions": [
-
-              ]
-            }
-          ],
-          "target": "notes.staffOnly",
-          "subfield": [
-            "a",
-            "b",
-            "c",
-            "d",
-            "g",
-            "3"
-          ],
-          "description": "If true, determines that the note should not be visible for others than staff"
-        }
-      ]
-    }
-  ],
-  "536": [
-    {
-      "entity": [
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_note_type_id",
-                  "parameter": {
-                    "name": "Funding Information Note"
-                  }
-                }
-              ]
-            }
-          ],
-          "target": "notes.instanceNoteTypeId",
-          "subfield": [
-            "a",
-            "b",
-            "c",
-            "d",
-            "e",
-            "f",
-            "g",
-            "h"
-          ],
-          "description": "Instance note type id",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "trim_period"
-                }
-              ]
-            }
-          ],
-          "target": "notes.note",
-          "subfield": [
-            "a",
-            "b",
-            "c",
-            "d",
-            "e",
-            "f",
-            "g",
-            "h"
-          ],
-          "description": "Funding Information Note",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "value": "false",
-              "conditions": [
-
-              ]
-            }
-          ],
-          "target": "notes.staffOnly",
-          "subfield": [
-            "a",
-            "b",
-            "c",
-            "d",
-            "e",
-            "f",
-            "g",
-            "h"
-          ],
-          "description": "If true, determines that the note should not be visible for others than staff"
-        }
-      ]
-    }
-  ],
-  "538": [
-    {
-      "entity": [
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_note_type_id",
-                  "parameter": {
-                    "name": "System Details note"
-                  }
-                }
-              ]
-            }
-          ],
-          "target": "notes.instanceNoteTypeId",
-          "subfield": [
-            "a",
-            "u",
-            "3",
-            "5"
-          ],
-          "description": "Instance note type id",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "trim_period"
-                }
-              ]
-            }
-          ],
-          "target": "notes.note",
-          "subfield": [
-            "a",
-            "u",
-            "3",
-            "5"
-          ],
-          "description": "System Details Note",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "value": "false",
-              "conditions": [
-
-              ]
-            }
-          ],
-          "target": "notes.staffOnly",
-          "subfield": [
-            "a",
-            "u",
-            "3",
-            "5"
-          ],
-          "description": "If true, determines that the note should not be visible for others than staff"
-        }
-      ]
-    }
-  ],
-  "540": [
-    {
-      "entity": [
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_note_type_id",
-                  "parameter": {
-                    "name": "Terms Governing Use and Reproduction note"
-                  }
-                }
-              ]
-            }
-          ],
-          "target": "notes.instanceNoteTypeId",
-          "subfield": [
-            "a",
-            "b",
-            "c",
-            "d",
-            "u",
-            "3",
-            "5"
-          ],
-          "description": "Instance note type id",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "trim_period"
-                }
-              ]
-            }
-          ],
-          "target": "notes.note",
-          "subfield": [
-            "a",
-            "b",
-            "c",
-            "d",
-            "u",
-            "3",
-            "5"
-          ],
-          "description": "Terms Governing Use and Reproduction Note",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "value": "false",
-              "conditions": [
-
-              ]
-            }
-          ],
-          "target": "notes.staffOnly",
-          "subfield": [
-            "a",
-            "b",
-            "c",
-            "d",
-            "u",
-            "3",
-            "5"
-          ],
-          "description": "If true, determines that the note should not be visible for others than staff"
-        }
-      ]
-    }
-  ],
-  "541": [
-    {
-      "entity": [
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_note_type_id",
-                  "parameter": {
-                    "name": "Immediate Source of Acquisition note"
-                  }
-                }
-              ]
-            }
-          ],
-          "target": "notes.instanceNoteTypeId",
-          "subfield": [
-            "a",
-            "b",
-            "c",
-            "d",
-            "e",
-            "f",
-            "h",
-            "n",
-            "o",
-            "3",
-            "5"
-          ],
-          "description": "Instance note type id",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "trim_period"
-                }
-              ]
-            }
-          ],
-          "target": "notes.note",
-          "subfield": [
-            "a",
-            "b",
-            "c",
-            "d",
-            "e",
-            "f",
-            "h",
-            "n",
-            "o",
-            "3",
-            "5"
-          ],
-          "description": "Immediate Source of Acquisition Note",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_note_staff_only_via_indicator"
-                }
-              ]
-            }
-          ],
-          "target": "notes.staffOnly",
-          "subfield": [
-            "a",
-            "b",
-            "c",
-            "d",
-            "e",
-            "f",
-            "h",
-            "n",
-            "o",
-            "3",
-            "5"
-          ],
-          "description": "If true, determines that the note should not be visible for others than staff",
-          "applyRulesOnConcatenatedData": true
-        }
-      ]
-    }
-  ],
-  "542": [
-    {
-      "entity": [
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_note_type_id",
-                  "parameter": {
-                    "name": "Information related to Copyright Status"
-                  }
-                }
-              ]
-            }
-          ],
-          "target": "notes.instanceNoteTypeId",
-          "subfield": [
-            "a",
-            "b",
-            "c",
-            "d",
-            "e",
-            "f",
-            "g",
-            "h",
-            "i",
-            "j",
-            "k",
-            "l",
-            "m",
-            "n",
-            "o",
-            "p",
-            "q",
-            "r",
-            "s",
-            "u",
-            "3"
-          ],
-          "description": "Instance note type id",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "trim_period"
-                }
-              ]
-            }
-          ],
-          "target": "notes.note",
-          "subfield": [
-            "a",
-            "b",
-            "c",
-            "d",
-            "e",
-            "f",
-            "g",
-            "h",
-            "i",
-            "j",
-            "k",
-            "l",
-            "m",
-            "n",
-            "o",
-            "p",
-            "q",
-            "r",
-            "s",
-            "u",
-            "3"
-          ],
-          "description": "Information Relating to Copyright Status",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_note_staff_only_via_indicator"
-                }
-              ]
-            }
-          ],
-          "target": "notes.staffOnly",
-          "subfield": [
-            "a",
-            "b",
-            "c",
-            "d",
-            "e",
-            "f",
-            "g",
-            "h",
-            "i",
-            "j",
-            "k",
-            "l",
-            "m",
-            "n",
-            "o",
-            "p",
-            "q",
-            "r",
-            "s",
-            "u",
-            "3"
-          ],
-          "description": "If true, determines that the note should not be visible for others than staff",
-          "applyRulesOnConcatenatedData": true
-        }
-      ]
-    }
-  ],
-  "544": [
-    {
-      "entity": [
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_note_type_id",
-                  "parameter": {
-                    "name": "Location of Other Archival Materials note"
-                  }
-                }
-              ]
-            }
-          ],
-          "target": "notes.instanceNoteTypeId",
-          "subfield": [
-            "a",
-            "b",
-            "c",
-            "d",
-            "e",
-            "n",
-            "3"
-          ],
-          "description": "Instance note type id",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "trim_period"
-                }
-              ]
-            }
-          ],
-          "target": "notes.note",
-          "subfield": [
-            "a",
-            "b",
-            "c",
-            "d",
-            "e",
-            "n",
-            "3"
-          ],
-          "description": "Location of Other Archival Materials Note",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "value": "false",
-              "conditions": [
-
-              ]
-            }
-          ],
-          "target": "notes.staffOnly",
-          "subfield": [
-            "a",
-            "b",
-            "c",
-            "d",
-            "e",
-            "n",
-            "3"
-          ],
-          "description": "If true, determines that the note should not be visible for others than staff"
-        }
-      ]
-    }
-  ],
-  "545": [
-    {
-      "entity": [
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_note_type_id",
-                  "parameter": {
-                    "name": "Biographical or Historical Data"
-                  }
-                }
-              ]
-            }
-          ],
-          "target": "notes.instanceNoteTypeId",
-          "subfield": [
-            "a",
-            "b",
-            "u"
-          ],
-          "description": "Instance note type id",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "trim_period"
-                }
-              ]
-            }
-          ],
-          "target": "notes.note",
-          "subfield": [
-            "a",
-            "b",
-            "u"
-          ],
-          "description": "Biographical or Historical Data",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "value": "false",
-              "conditions": [
-
-              ]
-            }
-          ],
-          "target": "notes.staffOnly",
-          "subfield": [
-            "a",
-            "b",
-            "u"
-          ],
-          "description": "If true, determines that the note should not be visible for others than staff"
-        }
-      ]
-    }
-  ],
-  "546": [
-    {
-      "entity": [
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_note_type_id",
-                  "parameter": {
-                    "name": "Language note"
-                  }
-                }
-              ]
-            }
-          ],
-          "target": "notes.instanceNoteTypeId",
-          "subfield": [
-            "a",
-            "b",
-            "3"
-          ],
-          "description": "Instance note type id",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "trim_period"
-                }
-              ]
-            }
-          ],
-          "target": "notes.note",
-          "subfield": [
-            "a",
-            "b",
-            "3"
-          ],
-          "description": "Language Note",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "value": "false",
-              "conditions": [
-
-              ]
-            }
-          ],
-          "target": "notes.staffOnly",
-          "subfield": [
-            "a",
-            "b",
-            "3"
-          ],
-          "description": "If true, determines that the note should not be visible for others than staff"
-        }
-      ]
-    }
-  ],
-  "547": [
-    {
-      "entity": [
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_note_type_id",
-                  "parameter": {
-                    "name": "Former Title Complexity note"
-                  }
-                }
-              ]
-            }
-          ],
-          "target": "notes.instanceNoteTypeId",
-          "subfield": [
-            "a"
-          ],
-          "description": "Instance note type id",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "trim_period"
-                }
-              ]
-            }
-          ],
-          "target": "notes.note",
-          "subfield": [
-            "a"
-          ],
-          "description": "Former Title Complexity Note",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "value": "false",
-              "conditions": [
-
-              ]
-            }
-          ],
-          "target": "notes.staffOnly",
-          "subfield": [
-            "a"
-          ],
-          "description": "If true, determines that the note should not be visible for others than staff"
-        }
-      ]
-    }
-  ],
-  "550": [
-    {
-      "entity": [
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_note_type_id",
-                  "parameter": {
-                    "name": "Issuing Body note"
-                  }
-                }
-              ]
-            }
-          ],
-          "target": "notes.instanceNoteTypeId",
-          "subfield": [
-            "a"
-          ],
-          "description": "Instance note type id",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "trim_period"
-                }
-              ]
-            }
-          ],
-          "target": "notes.note",
-          "subfield": [
-            "a"
-          ],
-          "description": "Issuing Body Note",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "value": "false",
-              "conditions": [
-
-              ]
-            }
-          ],
-          "target": "notes.staffOnly",
-          "subfield": [
-            "a"
-          ],
-          "description": "If true, determines that the note should not be visible for others than staff"
-        }
-      ]
-    }
-  ],
-  "552": [
-    {
-      "entity": [
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_note_type_id",
-                  "parameter": {
-                    "name": "Entity and Attribute Information note"
-                  }
-                }
-              ]
-            }
-          ],
-          "target": "notes.instanceNoteTypeId",
-          "subfield": [
-            "a",
-            "b",
-            "c",
-            "d",
-            "e",
-            "f",
-            "g",
-            "h",
-            "i",
-            "j",
-            "k",
-            "l",
-            "m",
-            "n",
-            "o",
-            "p",
-            "u",
-            "z"
-          ],
-          "description": "Instance note type id",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "trim_period"
-                }
-              ]
-            }
-          ],
-          "target": "notes.note",
-          "subfield": [
-            "a",
-            "b",
-            "c",
-            "d",
-            "e",
-            "f",
-            "g",
-            "h",
-            "i",
-            "j",
-            "k",
-            "l",
-            "m",
-            "n",
-            "o",
-            "p",
-            "u",
-            "z"
-          ],
-          "description": "Entity and Attribute Information Note",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "value": "false",
-              "conditions": [
-
-              ]
-            }
-          ],
-          "target": "notes.staffOnly",
-          "subfield": [
-            "a",
-            "b",
-            "c",
-            "d",
-            "e",
-            "f",
-            "g",
-            "h",
-            "i",
-            "j",
-            "k",
-            "l",
-            "m",
-            "n",
-            "o",
-            "p",
-            "u",
-            "z"
-          ],
-          "description": "If true, determines that the note should not be visible for others than staff"
-        }
-      ]
-    }
-  ],
-  "555": [
-    {
-      "entity": [
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_note_type_id",
-                  "parameter": {
-                    "name": "Cumulative Index / Finding Aides notes"
-                  }
-                }
-              ]
-            }
-          ],
-          "target": "notes.instanceNoteTypeId",
-          "subfield": [
-            "a",
-            "b",
-            "c",
-            "d",
-            "u",
-            "3"
-          ],
-          "description": "Instance note type id",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "trim_period"
-                }
-              ]
-            }
-          ],
-          "target": "notes.note",
-          "subfield": [
-            "a",
-            "b",
-            "c",
-            "d",
-            "u",
-            "3"
-          ],
-          "description": "Cumulative Index/Finding Aids Note",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "value": "false",
-              "conditions": [
-
-              ]
-            }
-          ],
-          "target": "notes.staffOnly",
-          "subfield": [
-            "a",
-            "b",
-            "c",
-            "d",
-            "u",
-            "3"
-          ],
-          "description": "If true, determines that the note should not be visible for others than staff"
-        }
-      ]
-    }
-  ],
-  "556": [
-    {
-      "entity": [
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_note_type_id",
-                  "parameter": {
-                    "name": "Information About Documentation note"
-                  }
-                }
-              ]
-            }
-          ],
-          "target": "notes.instanceNoteTypeId",
-          "subfield": [
-            "a",
-            "z"
-          ],
-          "description": "Instance note type id",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "trim_period"
-                }
-              ]
-            }
-          ],
-          "target": "notes.note",
-          "subfield": [
-            "a",
-            "z"
-          ],
-          "description": "Information About Documentation Note",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "value": "false",
-              "conditions": [
-
-              ]
-            }
-          ],
-          "target": "notes.staffOnly",
-          "subfield": [
-            "a",
-            "z"
-          ],
-          "description": "If true, determines that the note should not be visible for others than staff"
-        }
-      ]
-    }
-  ],
-  "561": [
-    {
-      "entity": [
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_note_type_id",
-                  "parameter": {
-                    "name": "Ownership and Custodial History note"
-                  }
-                }
-              ]
-            }
-          ],
-          "target": "notes.instanceNoteTypeId",
-          "subfield": [
-            "a",
-            "u",
-            "3",
-            "5"
-          ],
-          "description": "Instance note type id",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "trim_period"
-                }
-              ]
-            }
-          ],
-          "target": "notes.note",
-          "subfield": [
-            "a",
-            "u",
-            "3",
-            "5"
-          ],
-          "description": "Ownership and Custodial History",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_note_staff_only_via_indicator"
-                }
-              ]
-            }
-          ],
-          "target": "notes.staffOnly",
-          "subfield": [
-            "a",
-            "u",
-            "3",
-            "5"
-          ],
-          "description": "If true, determines that the note should not be visible for others than staff",
-          "applyRulesOnConcatenatedData": true
-        }
-      ]
-    }
-  ],
-  "562": [
-    {
-      "entity": [
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_note_type_id",
-                  "parameter": {
-                    "name": "Copy and Version Identification note"
-                  }
-                }
-              ]
-            }
-          ],
-          "target": "notes.instanceNoteTypeId",
-          "subfield": [
-            "a",
-            "b",
-            "c",
-            "d",
-            "e",
-            "3",
-            "5"
-          ],
-          "description": "Instance note type id",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "trim_period"
-                }
-              ]
-            }
-          ],
-          "target": "notes.note",
-          "subfield": [
-            "a",
-            "b",
-            "c",
-            "d",
-            "e",
-            "3",
-            "5"
-          ],
-          "description": "Copy and Version Identification Note",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "value": "false",
-              "conditions": [
-
-              ]
-            }
-          ],
-          "target": "notes.staffOnly",
-          "subfield": [
-            "a",
-            "b",
-            "c",
-            "d",
-            "e",
-            "3",
-            "5"
-          ],
-          "description": "If true, determines that the note should not be visible for others than staff"
-        }
-      ]
-    }
-  ],
-  "563": [
-    {
-      "entity": [
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_note_type_id",
-                  "parameter": {
-                    "name": "Binding Information note"
-                  }
-                }
-              ]
-            }
-          ],
-          "target": "notes.instanceNoteTypeId",
-          "subfield": [
-            "a",
-            "u",
-            "3",
-            "5"
-          ],
-          "description": "Instance note type id",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "trim_period"
-                }
-              ]
-            }
-          ],
-          "target": "notes.note",
-          "subfield": [
-            "a",
-            "u",
-            "3",
-            "5"
-          ],
-          "description": "Binding Information",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "value": "false",
-              "conditions": [
-
-              ]
-            }
-          ],
-          "target": "notes.staffOnly",
-          "subfield": [
-            "a",
-            "u",
-            "3",
-            "5"
-          ],
-          "description": "If true, determines that the note should not be visible for others than staff"
-        }
-      ]
-    }
-  ],
-  "565": [
-    {
-      "entity": [
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_note_type_id",
-                  "parameter": {
-                    "name": "Case File Characteristics note"
-                  }
-                }
-              ]
-            }
-          ],
-          "target": "notes.instanceNoteTypeId",
-          "subfield": [
-            "a",
-            "b",
-            "c",
-            "d",
-            "e",
-            "3"
-          ],
-          "description": "Instance note type id",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "trim_period"
-                }
-              ]
-            }
-          ],
-          "target": "notes.note",
-          "subfield": [
-            "a",
-            "b",
-            "c",
-            "d",
-            "e",
-            "3"
-          ],
-          "description": "Case File Characteristics Note",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "value": "false",
-              "conditions": [
-
-              ]
-            }
-          ],
-          "target": "notes.staffOnly",
-          "subfield": [
-            "a",
-            "b",
-            "c",
-            "d",
-            "e",
-            "3"
-          ],
-          "description": "If true, determines that the note should not be visible for others than staff"
-        }
-      ]
-    }
-  ],
-  "567": [
-    {
-      "entity": [
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_note_type_id",
-                  "parameter": {
-                    "name": "Methodology note"
-                  }
-                }
-              ]
-            }
-          ],
-          "target": "notes.instanceNoteTypeId",
-          "subfield": [
-            "a",
-            "b",
-            "2"
-          ],
-          "description": "Instance note type id",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "trim_period"
-                }
-              ]
-            }
-          ],
-          "target": "notes.note",
-          "subfield": [
-            "a",
-            "b",
-            "2"
-          ],
-          "description": "Methodology Note",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "value": "false",
-              "conditions": [
-
-              ]
-            }
-          ],
-          "target": "notes.staffOnly",
-          "subfield": [
-            "a",
-            "b",
-            "2"
-          ],
-          "description": "If true, determines that the note should not be visible for others than staff"
-        }
-      ]
-    }
-  ],
-  "580": [
-    {
-      "entity": [
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_note_type_id",
-                  "parameter": {
-                    "name": "Linking Entry Complexity note"
-                  }
-                }
-              ]
-            }
-          ],
-          "target": "notes.instanceNoteTypeId",
-          "subfield": [
-            "a"
-          ],
-          "description": "Instance note type id",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "trim_period"
-                }
-              ]
-            }
-          ],
-          "target": "notes.note",
-          "subfield": [
-            "a"
-          ],
-          "description": "Linking Entry Complexity Note",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "value": "false",
-              "conditions": [
-
-              ]
-            }
-          ],
-          "target": "notes.staffOnly",
-          "subfield": [
-            "a"
-          ],
-          "description": "If true, determines that the note should not be visible for others than staff"
-        }
-      ]
-    }
-  ],
-  "581": [
-    {
-      "entity": [
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_note_type_id",
-                  "parameter": {
-                    "name": "Publications About Described Materials note"
-                  }
-                }
-              ]
-            }
-          ],
-          "target": "notes.instanceNoteTypeId",
-          "subfield": [
-            "a",
-            "z",
-            "3"
-          ],
-          "description": "Instance note type id",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "trim_period"
-                }
-              ]
-            }
-          ],
-          "target": "notes.note",
-          "subfield": [
-            "a",
-            "z",
-            "3"
-          ],
-          "description": "Publications About Described Materials Note",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "value": "false",
-              "conditions": [
-
-              ]
-            }
-          ],
-          "target": "notes.staffOnly",
-          "subfield": [
-            "a",
-            "z",
-            "3"
-          ],
-          "description": "If true, determines that the note should not be visible for others than staff"
-        }
-      ]
-    }
-  ],
-  "583": [
-    {
-      "entity": [
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_note_type_id",
-                  "parameter": {
-                    "name": "Action note"
-                  }
-                }
-              ]
-            }
-          ],
-          "target": "notes.instanceNoteTypeId",
-          "subfield": [
-            "a",
-            "b",
-            "c",
-            "d",
-            "e",
-            "f",
-            "h",
-            "i",
-            "j",
-            "k",
-            "l",
-            "n",
-            "o",
-            "u",
-            "x",
-            "z",
-            "2",
-            "3",
-            "5"
-          ],
-          "description": "Instance note type id",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "trim_period"
-                }
-              ]
-            }
-          ],
-          "target": "notes.note",
-          "subfield": [
-            "a",
-            "b",
-            "c",
-            "d",
-            "e",
-            "f",
-            "h",
-            "i",
-            "j",
-            "k",
-            "l",
-            "n",
-            "o",
-            "u",
-            "x",
-            "z",
-            "2",
-            "3",
-            "5"
-          ],
-          "description": "Action Note",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_note_staff_only_via_indicator"
-                }
-              ]
-            }
-          ],
-          "target": "notes.staffOnly",
-          "subfield": [
-            "a",
-            "b",
-            "c",
-            "d",
-            "e",
-            "f",
-            "h",
-            "i",
-            "j",
-            "k",
-            "l",
-            "n",
-            "o",
-            "u",
-            "x",
-            "z",
-            "2",
-            "3",
-            "5"
-          ],
-          "description": "If true, determines that the note should not be visible for others than staff",
-          "applyRulesOnConcatenatedData": true
-        }
-      ]
-    }
-  ],
-  "584": [
-    {
-      "entity": [
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_note_type_id",
-                  "parameter": {
-                    "name": "Accumulation and Frequency of Use note"
-                  }
-                }
-              ]
-            }
-          ],
-          "target": "notes.instanceNoteTypeId",
-          "subfield": [
-            "a",
-            "b",
-            "3",
-            "5"
-          ],
-          "description": "Instance note type id",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "trim_period"
-                }
-              ]
-            }
-          ],
-          "target": "notes.note",
-          "subfield": [
-            "a",
-            "b",
-            "3",
-            "5"
-          ],
-          "description": "Accumulation and Frequency of Use Note",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "value": "false",
-              "conditions": [
-
-              ]
-            }
-          ],
-          "target": "notes.staffOnly",
-          "subfield": [
-            "a",
-            "b",
-            "3",
-            "5"
-          ],
-          "description": "If true, determines that the note should not be visible for others than staff"
-        }
-      ]
-    }
-  ],
-  "585": [
-    {
-      "entity": [
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_note_type_id",
-                  "parameter": {
-                    "name": "Exhibitions note"
-                  }
-                }
-              ]
-            }
-          ],
-          "target": "notes.instanceNoteTypeId",
-          "subfield": [
-            "a",
-            "3",
-            "5"
-          ],
-          "description": "Instance note type id",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "trim_period"
-                }
-              ]
-            }
-          ],
-          "target": "notes.note",
-          "subfield": [
-            "a",
-            "3",
-            "5"
-          ],
-          "description": "Exhibitions Note",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "value": "false",
-              "conditions": [
-
-              ]
-            }
-          ],
-          "target": "notes.staffOnly",
-          "subfield": [
-            "a",
-            "3",
-            "5"
-          ],
-          "description": "If true, determines that the note should not be visible for others than staff"
-        }
-      ]
-    }
-  ],
-  "586": [
-    {
-      "entity": [
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_note_type_id",
-                  "parameter": {
-                    "name": "Awards note"
-                  }
-                }
-              ]
-            }
-          ],
-          "target": "notes.instanceNoteTypeId",
-          "subfield": [
-            "a",
-            "3"
-          ],
-          "description": "Instance note type id",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "trim_period"
-                }
-              ]
-            }
-          ],
-          "target": "notes.note",
-          "subfield": [
-            "a",
-            "3"
-          ],
-          "description": "Awards Note",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "value": "false",
-              "conditions": [
-
-              ]
-            }
-          ],
-          "target": "notes.staffOnly",
-          "subfield": [
-            "a",
-            "3"
-          ],
-          "description": "If true, determines that the note should not be visible for others than staff"
-        }
-      ]
-    }
-  ],
-  "588": [
-    {
-      "entity": [
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_note_type_id",
-                  "parameter": {
-                    "name": "Source of Description note"
-                  }
-                }
-              ]
-            }
-          ],
-          "target": "notes.instanceNoteTypeId",
-          "subfield": [
-            "a",
-            "5"
-          ],
-          "description": "Instance note type id",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "trim_period"
-                }
-              ]
-            }
-          ],
-          "target": "notes.note",
-          "subfield": [
-            "a",
-            "5"
-          ],
-          "description": "Source of Description Note",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "value": "false",
-              "conditions": [
-
-              ]
-            }
-          ],
-          "target": "notes.staffOnly",
-          "subfield": [
-            "a",
-            "5"
-          ],
-          "description": "If true, determines that the note should not be visible for others than staff"
-        }
-      ]
-    }
-  ],
-  "590": [
-    {
-      "entity": [
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_note_type_id",
-                  "parameter": {
-                    "name": "Local notes"
-                  }
-                }
-              ]
-            }
-          ],
-          "target": "notes.instanceNoteTypeId",
-          "subfield": [
-            "a"
-          ],
-          "description": "Instance note type id",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "trim_period"
-                }
-              ]
-            }
-          ],
-          "target": "notes.note",
-          "subfield": [
-            "a"
-          ],
-          "description": "Local notes",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_note_staff_only_via_indicator"
-                }
-              ]
-            }
-          ],
-          "target": "notes.staffOnly",
-          "subfield": [
-            "a"
-          ],
-          "description": "If the 1st indicator equals 0, determines that the note should not be visible for others than staff"
-        }
-      ]
-    }
-  ],
-  "600": [
-    {
-      "rules": [
-        {
-          "conditions": [
-            {
-              "type": "trim_period, trim"
-            }
-          ]
-        }
-      ],
-      "target": "subjects",
-      "subfield": [
-        "a",
-        "b",
-        "c",
-        "d",
-        "e",
-        "f",
-        "g",
-        "h",
-        "j",
-        "k",
-        "l",
-        "m",
-        "n",
-        "o",
-        "p",
-        "q",
-        "r",
-        "s",
-        "t",
-        "u",
-        "v",
-        "x",
-        "y",
-        "z"
-      ],
-      "description": "Subject Headings",
-      "subFieldDelimiter": [
-        {
-          "value": " ",
-          "subfields": [
-            "a",
-            "b",
-            "c",
-            "d",
-            "j",
-            "q",
-            "t",
-            "f",
-            "g",
-            "k",
-            "l",
-            "m",
-            "n",
-            "o",
-            "p",
-            "r",
-            "s"
-          ]
-        },
-        {
-          "value": "--",
-          "subfields": [
-            "x",
-            "y",
-            "z",
-            "v"
-          ]
-        },
-        {
-          "value": "--",
-          "subfields": [
-
-          ]
-        }
-      ],
-      "applyRulesOnConcatenatedData": true
-    }
-  ],
-  "610": [
-    {
-      "rules": [
-        {
-          "conditions": [
-            {
-              "type": "trim_period, trim"
-            }
-          ]
-        }
-      ],
-      "target": "subjects",
-      "subfield": [
-        "a",
-        "b",
-        "c",
-        "d",
-        "e",
-        "f",
-        "g",
-        "h",
-        "k",
-        "l",
-        "m",
-        "n",
-        "o",
-        "p",
-        "r",
-        "s",
-        "t",
-        "u",
-        "v",
-        "x",
-        "y",
-        "z"
-      ],
-      "description": "Subject Headings",
-      "subFieldDelimiter": [
-        {
-          "value": " ",
-          "subfields": [
-            "a",
-            "b",
-            "c",
-            "d",
-            "t",
-            "f",
-            "g",
-            "k",
-            "l",
-            "m",
-            "n",
-            "o",
-            "p",
-            "s"
-          ]
-        },
-        {
-          "value": "--",
-          "subfields": [
-            "x",
-            "y",
-            "z",
-            "v"
-          ]
-        },
-        {
-          "value": "--",
-          "subfields": [
-
-          ]
-        }
-      ],
-      "applyRulesOnConcatenatedData": true
-    }
-  ],
-  "611": [
-    {
-      "rules": [
-        {
-          "conditions": [
-            {
-              "type": "trim_period, trim"
-            }
-          ]
-        }
-      ],
-      "target": "subjects",
-      "subfield": [
-        "a",
-        "c",
-        "d",
-        "e",
-        "f",
-        "g",
-        "h",
-        "j",
-        "k",
-        "l",
-        "n",
-        "p",
-        "q",
-        "s",
-        "t",
-        "u",
-        "v",
-        "x",
-        "y",
-        "z"
-      ],
-      "description": "Subject Headings",
-      "subFieldDelimiter": [
-        {
-          "value": " ",
-          "subfields": [
-            "a",
-            "c",
-            "d",
-            "e",
-            "q",
-            "t",
-            "f",
-            "g",
-            "k",
-            "l",
-            "m",
-            "n",
-            "o",
-            "p",
-            "r",
-            "s"
-          ]
-        },
-        {
-          "value": "--",
-          "subfields": [
-            "x",
-            "y",
-            "z",
-            "v"
-          ]
-        },
-        {
-          "value": "--",
-          "subfields": [
-
-          ]
-        }
-      ],
-      "applyRulesOnConcatenatedData": true
-    }
-  ],
-  "630": [
-    {
-      "rules": [
-        {
-          "conditions": [
-            {
-              "type": "trim_period, trim"
-            }
-          ]
-        }
-      ],
-      "target": "subjects",
-      "subfield": [
-        "a",
-        "d",
-        "e",
-        "f",
-        "g",
-        "h",
-        "k",
-        "l",
-        "m",
-        "n",
-        "o",
-        "p",
-        "r",
-        "s",
-        "t",
-        "v",
-        "x",
-        "y",
-        "z"
-      ],
-      "description": "Subject Headings",
-      "subFieldDelimiter": [
-        {
-          "value": " ",
-          "subfields": [
-            "a",
-            "d",
-            "f",
-            "g",
-            "k",
-            "l",
-            "m",
-            "n",
-            "o",
-            "p",
-            "r",
-            "s"
-          ]
-        },
-        {
-          "value": "--",
-          "subfields": [
-            "x",
-            "y",
-            "z",
-            "v"
-          ]
-        },
-        {
-          "value": "--",
-          "subfields": [
-
-          ]
-        }
-      ],
-      "applyRulesOnConcatenatedData": true
-    }
-  ],
-  "647": [
-    {
-      "rules": [
-        {
-          "conditions": [
-            {
-              "type": "trim_period, trim"
-            }
-          ]
-        }
-      ],
-      "target": "subjects",
-      "subfield": [
-        "a",
-        "c",
-        "d",
-        "g",
-        "x",
-        "y",
-        "z",
-        "v"
-      ],
-      "description": "Subject Headings",
-      "subFieldDelimiter": [
-        {
-          "value": "--",
-          "subfields": [
-            "a",
-            "c",
-            "d",
-            "g",
-            "x",
-            "y",
-            "z",
-            "v"
-          ]
-        },
-        {
-          "value": "--",
-          "subfields": [
-
-          ]
-        }
-      ],
-      "applyRulesOnConcatenatedData": true
-    }
-  ],
-  "648": [
-    {
-      "rules": [
-        {
-          "conditions": [
-            {
-              "type": "trim_period, trim"
-            }
-          ]
-        }
-      ],
-      "target": "subjects",
-      "subfield": [
-        "a",
-        "x",
-        "y",
-        "z",
-        "v"
-      ],
-      "description": "Subject Headings",
-      "subFieldDelimiter": [
-        {
-          "value": "--",
-          "subfields": [
-            "a",
-            "x",
-            "y",
-            "z",
-            "v"
-          ]
-        }
-      ],
-      "applyRulesOnConcatenatedData": true
-    }
-  ],
-  "650": [
-    {
-      "rules": [
-        {
-          "conditions": [
-            {
-              "type": "trim_period, trim"
-            }
-          ]
-        }
-      ],
-      "target": "subjects",
-      "subfield": [
-        "a",
-        "b",
-        "c",
-        "d",
-        "e",
-        "g",
-        "v",
-        "x",
-        "y",
-        "z"
-      ],
-      "description": "Subject Headings",
-      "subFieldDelimiter": [
-        {
-          "value": "--",
-          "subfields": [
-            "a",
-            "b",
-            "c",
-            "d",
-            "e",
-            "g",
-            "v",
-            "x",
-            "y",
-            "z"
-          ]
-        }
-      ],
-      "applyRulesOnConcatenatedData": true
-    }
-  ],
-  "651": [
-    {
-      "rules": [
-        {
-          "conditions": [
-            {
-              "type": "trim_period, trim"
-            }
-          ]
-        }
-      ],
-      "target": "subjects",
-      "subfield": [
-        "a",
-        "e",
-        "g",
-        "v",
-        "x",
-        "y",
-        "z"
-      ],
-      "description": "Subject Headings",
-      "subFieldDelimiter": [
-        {
-          "value": "--",
-          "subfields": [
-            "a",
-            "e",
-            "g",
-            "v",
-            "x",
-            "y",
-            "z"
-          ]
-        }
-      ],
-      "applyRulesOnConcatenatedData": true
-    }
-  ],
-  "655": [
-    {
-      "rules": [
-        {
-          "conditions": [
-            {
-              "type": "trim_period, trim"
-            }
-          ]
-        }
-      ],
-      "target": "subjects",
-      "subfield": [
-        "a",
-        "b",
-        "c",
-        "v",
-        "x",
-        "y",
-        "z"
-      ],
-      "description": "Subject Headings",
-      "subFieldDelimiter": [
-        {
-          "value": "--",
-          "subfields": [
-            "a",
-            "e",
-            "g",
-            "v",
-            "x",
-            "y",
-            "z"
-          ]
-        }
-      ],
-      "applyRulesOnConcatenatedData": true
-    }
-  ],
-  "700": [
-    {
-      "entity": [
-        {
-          "target": "contributors.authorityId",
-          "subfield": [
-            "9"
-          ],
-          "description": "Authority ID that controlling the contributor",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_contributor_name_type_id",
-                  "parameter": {
-                    "name": "Personal name"
-                  }
-                }
-              ]
-            }
-          ],
-          "target": "contributors.contributorNameTypeId",
-          "subfield": [
-
-          ],
-          "description": "Type for Personal Name",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_contributor_type_id"
-                }
-              ]
-            }
-          ],
-          "target": "contributors.contributorTypeId",
-          "subfield": [
-            "4"
-          ],
-          "description": "Type of contributor",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_contributor_type_text"
-                }
-              ]
-            }
-          ],
-          "target": "contributors.contributorTypeText",
-          "subfield": [
-            "e"
-          ],
-          "description": "Contributor type free text",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "value": "false",
-              "conditions": [
-
-              ]
-            }
-          ],
-          "target": "contributors.primary",
-          "subfield": [
-
-          ],
-          "description": "Primary contributor",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "trim_period, trim"
-                }
-              ]
-            }
-          ],
-          "target": "contributors.name",
-          "subfield": [
-            "a",
-            "b",
-            "c",
-            "d",
-            "f",
-            "g",
-            "j",
-            "k",
-            "l",
-            "n",
-            "p",
-            "q",
-            "t",
-            "u"
-          ],
-          "description": "Personal Name",
-          "applyRulesOnConcatenatedData": true
-        }
-      ]
-    }
-  ],
-  "710": [
-    {
-      "entity": [
-        {
-          "target": "contributors.authorityId",
-          "subfield": [
-            "9"
-          ],
-          "description": "Authority ID that controlling the contributor",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_contributor_name_type_id",
-                  "parameter": {
-                    "name": "Corporate name"
-                  }
-                }
-              ]
-            }
-          ],
-          "target": "contributors.contributorNameTypeId",
-          "subfield": [
-
-          ],
-          "description": "Type for Corporate Name",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_contributor_type_id"
-                }
-              ]
-            }
-          ],
-          "target": "contributors.contributorTypeId",
-          "subfield": [
-            "4"
-          ],
-          "description": "Type of contributor",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_contributor_type_text"
-                }
-              ]
-            }
-          ],
-          "target": "contributors.contributorTypeText",
-          "subfield": [
-            "e"
-          ],
-          "description": "Contributor type free text",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "value": "false",
-              "conditions": [
-
-              ]
-            }
-          ],
-          "target": "contributors.primary",
-          "subfield": [
-
-          ],
-          "description": "Primary contributor",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "trim_period, trim"
-                }
-              ]
-            }
-          ],
-          "target": "contributors.name",
-          "subfield": [
-            "a",
-            "b",
-            "c",
-            "d",
-            "f",
-            "g",
-            "k",
-            "l",
-            "n",
-            "p",
-            "t",
-            "u"
-          ],
-          "description": "Corporate Name",
-          "applyRulesOnConcatenatedData": true
-        }
-      ]
-    }
-  ],
-  "711": [
-    {
-      "entity": [
-        {
-          "target": "contributors.authorityId",
-          "subfield": [
-            "9"
-          ],
-          "description": "Authority ID that controlling the contributor",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_contributor_name_type_id",
-                  "parameter": {
-                    "name": "Meeting name"
-                  }
-                }
-              ]
-            }
-          ],
-          "target": "contributors.contributorNameTypeId",
-          "subfield": [
-
-          ],
-          "description": "Type for Meeting Name",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_contributor_type_id"
-                }
-              ]
-            }
-          ],
-          "target": "contributors.contributorTypeId",
-          "subfield": [
-            "4"
-          ],
-          "description": "Type of contributor",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_contributor_type_text"
-                }
-              ]
-            }
-          ],
-          "target": "contributors.contributorTypeText",
-          "subfield": [
-            "j"
-          ],
-          "description": "Contributor type free text",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "value": "false",
-              "conditions": [
-
-              ]
-            }
-          ],
-          "target": "contributors.primary",
-          "subfield": [
-
-          ],
-          "description": "Primary contributor",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "trim_period, trim"
-                }
-              ]
-            }
-          ],
-          "target": "contributors.name",
-          "subfield": [
-            "a",
-            "b",
-            "c",
-            "d",
-            "f",
-            "g",
-            "k",
-            "l",
-            "n",
-            "p",
-            "t",
-            "u"
-          ],
-          "description": "Meeting Name",
-          "applyRulesOnConcatenatedData": true
-        }
-      ]
-    }
-  ],
-  "780": [
-    {
-      "entity": [
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "trim"
-                }
-              ]
-            }
-          ],
-          "target": "precedingTitles.title",
-          "subfield": [
-            "t"
-          ],
-          "description": "The primary title (or label) associated with the resource",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_identifier_type_id_by_name",
-                  "parameter": {
-                    "name": "ISBN"
-                  }
-                }
-              ]
-            }
-          ],
-          "target": "precedingTitles.isbnId",
-          "subfield": [
-            "z"
-          ],
-          "description": "Type for Valid ISBN",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "trim"
-                }
-              ]
-            }
-          ],
-          "target": "precedingTitles.isbnValue",
-          "subfield": [
-            "z"
-          ],
-          "description": "Value for Valid ISBN",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_identifier_type_id_by_name",
-                  "parameter": {
-                    "name": "ISSN"
-                  }
-                }
-              ]
-            }
-          ],
-          "target": "precedingTitles.issnId",
-          "subfield": [
-            "x"
-          ],
-          "description": "Type for Valid ISSN",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "trim"
-                }
-              ]
-            }
-          ],
-          "target": "precedingTitles.issnValue",
-          "subfield": [
-            "x"
-          ],
-          "description": "Value for Valid ISSN",
-          "applyRulesOnConcatenatedData": true
-        }
-      ]
-    }
-  ],
-  "785": [
-    {
-      "entity": [
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "trim"
-                }
-              ]
-            }
-          ],
-          "target": "succeedingTitles.title",
-          "subfield": [
-            "t"
-          ],
-          "description": "The primary title (or label) associated with the resource",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_identifier_type_id_by_name",
-                  "parameter": {
-                    "name": "ISBN"
-                  }
-                }
-              ]
-            }
-          ],
-          "target": "succeedingTitles.isbnId",
-          "subfield": [
-            "z"
-          ],
-          "description": "Type for Valid ISBN",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "trim"
-                }
-              ]
-            }
-          ],
-          "target": "succeedingTitles.isbnValue",
-          "subfield": [
-            "z"
-          ],
-          "description": "Value for Valid ISBN",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_identifier_type_id_by_name",
-                  "parameter": {
-                    "name": "ISSN"
-                  }
-                }
-              ]
-            }
-          ],
-          "target": "succeedingTitles.issnId",
-          "subfield": [
-            "x"
-          ],
-          "description": "Type for Valid ISSN",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "trim"
-                }
-              ]
-            }
-          ],
-          "target": "succeedingTitles.issnValue",
-          "subfield": [
-            "x"
-          ],
-          "description": "Value for Valid ISSN",
-          "applyRulesOnConcatenatedData": true
-        }
-      ]
-    }
-  ],
-  "795": [
-    {
-      "entity": [
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_note_type_id",
-                  "parameter": {
-                    "name": "Collection name"
-                  }
-                }
-              ]
-            }
-          ],
-          "target": "notes.instanceNoteTypeId",
-          "subfield": [
-            "a",
-            "p"
-          ],
-          "description": "Instance note type id",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "trim_period"
-                }
-              ]
-            }
-          ],
-          "target": "notes.note",
-          "subfield": [
-            "a",
-            "p"
-          ],
-          "description": "Collection name",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "value": "false",
-              "conditions": [
-
-              ]
-            }
-          ],
-          "target": "notes.staffOnly",
-          "subfield": [
-            "a",
-            "p"
-          ],
-          "description": "If true, determines that the note should not be visible for others than staff"
-        }
-      ]
-    }
-  ],
-  "800": [
-    {
-      "rules": [
-        {
-          "conditions": [
-            {
-              "type": "remove_ending_punc, trim"
-            }
-          ]
-        }
-      ],
-      "target": "series",
-      "subfield": [
-        "a",
-        "b",
-        "c",
-        "d",
-        "e",
-        "f",
-        "g",
-        "h",
-        "j",
-        "k",
-        "l",
-        "m",
-        "n",
-        "o",
-        "p",
-        "q",
-        "r",
-        "s",
-        "t",
-        "u",
-        "v",
-        "w",
-        "x",
-        "3",
-        "5"
-      ],
-      "description": "Series Statement",
-      "applyRulesOnConcatenatedData": true
-    }
-  ],
-  "810": [
-    {
-      "rules": [
-        {
-          "conditions": [
-            {
-              "type": "remove_ending_punc, trim"
-            }
-          ]
-        }
-      ],
-      "target": "series",
-      "subfield": [
-        "a",
-        "b",
-        "c",
-        "d",
-        "e",
-        "f",
-        "g",
-        "h",
-        "k",
-        "l",
-        "m",
-        "n",
-        "o",
-        "p",
-        "r",
-        "s",
-        "t",
-        "u",
-        "v",
-        "w",
-        "x",
-        "3",
-        "5"
-      ],
-      "description": "Series Statement",
-      "applyRulesOnConcatenatedData": true
-    }
-  ],
-  "811": [
-    {
-      "rules": [
-        {
-          "conditions": [
-            {
-              "type": "remove_ending_punc, trim"
-            }
-          ]
-        }
-      ],
-      "target": "series",
-      "subfield": [
-        "a",
-        "c",
-        "d",
-        "e",
-        "f",
-        "g",
-        "h",
-        "j",
-        "k",
-        "l",
-        "n",
-        "p",
-        "q",
-        "s",
-        "t",
-        "u",
-        "v",
-        "w",
-        "x",
-        "3",
-        "5"
-      ],
-      "description": "Series Statement",
-      "applyRulesOnConcatenatedData": true
-    }
-  ],
-  "830": [
-    {
-      "rules": [
-        {
-          "conditions": [
-            {
-              "type": "remove_ending_punc, trim"
-            }
-          ]
-        }
-      ],
-      "target": "series",
-      "subfield": [
-        "a",
-        "d",
-        "f",
-        "g",
-        "h",
-        "k",
-        "l",
-        "m",
-        "n",
-        "o",
-        "p",
-        "r",
-        "s",
-        "t",
-        "v",
-        "w",
-        "x",
-        "3",
-        "5"
-      ],
-      "description": "Series Statement",
-      "applyRulesOnConcatenatedData": true
-    }
-  ],
-  "856": [
-    {
-      "entity": [
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_electronic_access_relations_id"
-                }
-              ]
-            }
-          ],
-          "target": "electronicAccess.relationshipId",
-          "subfield": [
-            "3",
-            "y",
-            "u",
-            "z"
-          ],
-          "description": "Relationship between the electronic resource at the location identified and the item described in the record as a whole",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "remove_ending_punc, trim"
-                }
-              ]
-            }
-          ],
-          "target": "electronicAccess.uri",
-          "subfield": [
-            "u"
-          ],
-          "description": "URI"
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "remove_ending_punc, trim"
-                }
-              ]
-            }
-          ],
-          "target": "electronicAccess.linkText",
-          "subfield": [
-            "y"
-          ],
-          "description": "Link text"
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "remove_ending_punc, trim"
-                }
-              ]
-            }
-          ],
-          "target": "electronicAccess.materialsSpecification",
-          "subfield": [
-            "3"
-          ],
-          "description": "Materials Specified"
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "remove_ending_punc, trim"
-                }
-              ]
-            }
-          ],
-          "target": "electronicAccess.publicNote",
-          "subfield": [
-            "z"
-          ],
-          "description": "URL public note"
-        }
-      ]
-    }
-  ],
-  "880": [
-    {
-      "target": "",
-      "subfield": [
-        "6"
-      ],
-      "description": "Field for target post-processing based on first 3 digits in subfield 6",
-      "fieldReplacementRule": [
-        {
-          "targetField": "700",
-          "sourceDigits": "100"
-        },
-        {
-          "targetField": "710",
-          "sourceDigits": "110"
-        },
-        {
-          "targetField": "711",
-          "sourceDigits": "111"
-        },
-        {
-          "targetField": "246",
-          "sourceDigits": "245"
-        }
-      ],
-      "fieldReplacementBy3Digits": true
-    }
-  ],
-  "910": [
-    {
-      "rules": [
-        {
-          "conditions": [
-            {
-              "type": "remove_ending_punc, trim"
-            }
-          ]
-        }
-      ],
-      "target": "administrativeNotes",
-      "subfield": [
-        "a"
-      ],
-      "description": "Administrative Note",
-      "applyRulesOnConcatenatedData": true
-    }
-  ],
-  "956": [
-    {
-      "entity": [
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_electronic_access_relations_id"
-                }
-              ]
-            }
-          ],
-          "target": "electronicAccess.relationshipId",
-          "subfield": [
-            "3",
-            "y",
-            "u",
-            "z"
-          ],
-          "description": "Relationship between the electronic resource at the location identified and the item described in the record as a whole",
-          "applyRulesOnConcatenatedData": true
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "remove_ending_punc, trim"
-                }
-              ]
-            }
-          ],
-          "target": "electronicAccess.uri",
-          "subfield": [
-            "u"
-          ],
-          "description": "URI"
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "remove_ending_punc, trim"
-                }
-              ]
-            }
-          ],
-          "target": "electronicAccess.linkText",
-          "subfield": [
-            "y"
-          ],
-          "description": "Link text"
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "remove_ending_punc, trim"
-                }
-              ]
-            }
-          ],
-          "target": "electronicAccess.materialsSpecification",
-          "subfield": [
-            "3"
-          ],
-          "description": "Materials Specified"
-        },
-        {
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "remove_ending_punc, trim"
-                }
-              ]
-            }
-          ],
-          "target": "electronicAccess.publicNote",
-          "subfield": [
-            "z"
-          ],
-          "description": "URL public note"
-        }
-      ]
-    }
-  ],
   "001": [
     {
-      "rules": [
-
-      ],
+      "rules": [],
       "target": "hrid",
-      "subfield": [
-
-      ],
+      "subfield": [],
       "description": "The human readable ID"
     },
     {
@@ -6569,9 +19,7 @@
         }
       ],
       "target": "modeOfIssuanceId",
-      "subfield": [
-
-      ],
+      "subfield": [],
       "description": ""
     }
   ],
@@ -6590,24 +38,18 @@
         }
       ],
       "target": "instanceTypeId",
-      "subfield": [
-
-      ],
+      "subfield": [],
       "description": "Default Unspecified Instance type in case when no 336 field present"
     },
     {
       "rules": [
         {
           "value": "MARC21",
-          "conditions": [
-
-          ]
+          "conditions": []
         }
       ],
       "target": "source",
-      "subfield": [
-
-      ],
+      "subfield": [],
       "description": "Source of instance record"
     },
     {
@@ -6625,9 +67,7 @@
         }
       ],
       "target": "languages",
-      "subfield": [
-
-      ],
+      "subfield": [],
       "description": "Language code"
     }
   ],
@@ -7635,6 +1075,6402 @@
           ],
           "description": "LC classification",
           "applyRulesOnConcatenatedData": true
+        }
+      ]
+    }
+  ],
+  "100": [
+    {
+      "entity": [
+        {
+          "target": "contributors.authorityId",
+          "subfield": [
+            "9"
+          ],
+          "description": "Authority ID that controlling the contributor",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_contributor_name_type_id",
+                  "parameter": {
+                    "name": "Personal name"
+                  }
+                }
+              ]
+            }
+          ],
+          "target": "contributors.contributorNameTypeId",
+          "subfield": [],
+          "description": "Type for Personal Name",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_contributor_type_id"
+                }
+              ]
+            }
+          ],
+          "target": "contributors.contributorTypeId",
+          "subfield": [
+            "4"
+          ],
+          "description": "Type of contributor",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_contributor_type_text"
+                }
+              ]
+            }
+          ],
+          "target": "contributors.contributorTypeText",
+          "subfield": [
+            "e"
+          ],
+          "description": "Contributor type free text",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "value": "true",
+              "conditions": []
+            }
+          ],
+          "target": "contributors.primary",
+          "subfield": [],
+          "description": "Primary contributor",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period, trim"
+                }
+              ]
+            }
+          ],
+          "target": "contributors.name",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "f",
+            "g",
+            "j",
+            "k",
+            "l",
+            "n",
+            "p",
+            "q",
+            "t",
+            "u"
+          ],
+          "description": "Personal Name",
+          "applyRulesOnConcatenatedData": true
+        }
+      ]
+    }
+  ],
+  "110": [
+    {
+      "entity": [
+        {
+          "target": "contributors.authorityId",
+          "subfield": [
+            "9"
+          ],
+          "description": "Authority ID that controlling the contributor",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_contributor_name_type_id",
+                  "parameter": {
+                    "name": "Corporate name"
+                  }
+                }
+              ]
+            }
+          ],
+          "target": "contributors.contributorNameTypeId",
+          "subfield": [],
+          "description": "Type for Corporate Name",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_contributor_type_text"
+                }
+              ]
+            }
+          ],
+          "target": "contributors.contributorTypeText",
+          "subfield": [
+            "e"
+          ],
+          "description": "Contributor type free text",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_contributor_type_id"
+                }
+              ]
+            }
+          ],
+          "target": "contributors.contributorTypeId",
+          "subfield": [
+            "4"
+          ],
+          "description": "Type of contributor",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "value": "true",
+              "conditions": []
+            }
+          ],
+          "target": "contributors.primary",
+          "subfield": [],
+          "description": "Primary contributor",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period, trim"
+                }
+              ]
+            }
+          ],
+          "target": "contributors.name",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "f",
+            "g",
+            "k",
+            "l",
+            "n",
+            "p",
+            "t",
+            "u"
+          ],
+          "description": "Corporate Name",
+          "applyRulesOnConcatenatedData": true
+        }
+      ]
+    }
+  ],
+  "111": [
+    {
+      "entity": [
+        {
+          "target": "contributors.authorityId",
+          "subfield": [
+            "9"
+          ],
+          "description": "Authority ID that controlling the contributor",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_contributor_name_type_id",
+                  "parameter": {
+                    "name": "Meeting name"
+                  }
+                }
+              ]
+            }
+          ],
+          "target": "contributors.contributorNameTypeId",
+          "subfield": [],
+          "description": "Type for Meeting Name",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_contributor_type_id"
+                }
+              ]
+            }
+          ],
+          "target": "contributors.contributorTypeId",
+          "subfield": [
+            "4"
+          ],
+          "description": "Type of contributor",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_contributor_type_text"
+                }
+              ]
+            }
+          ],
+          "target": "contributors.contributorTypeText",
+          "subfield": [
+            "j"
+          ],
+          "description": "Contributor type free text",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "value": "true",
+              "conditions": []
+            }
+          ],
+          "target": "contributors.primary",
+          "subfield": [],
+          "description": "Primary contributor",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period, trim"
+                }
+              ]
+            }
+          ],
+          "target": "contributors.name",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "f",
+            "g",
+            "k",
+            "l",
+            "n",
+            "p",
+            "t",
+            "u"
+          ],
+          "description": "Meeting Name",
+          "applyRulesOnConcatenatedData": true
+        }
+      ]
+    }
+  ],
+  "130": [
+    {
+      "entity": [
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_alternative_title_type_id",
+                  "parameter": {
+                    "name": "Uniform title"
+                  }
+                }
+              ]
+            }
+          ],
+          "target": "alternativeTitles.alternativeTitleTypeId",
+          "subfield": [
+            "a",
+            "n",
+            "p",
+            "d",
+            "f",
+            "g",
+            "h",
+            "k",
+            "l",
+            "m",
+            "o",
+            "r",
+            "s",
+            "t"
+          ],
+          "description": "Alternative Title id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "remove_ending_punc, trim"
+                }
+              ]
+            }
+          ],
+          "target": "alternativeTitles.alternativeTitle",
+          "subfield": [
+            "a",
+            "n",
+            "p",
+            "d",
+            "f",
+            "g",
+            "h",
+            "k",
+            "l",
+            "m",
+            "o",
+            "r",
+            "s",
+            "t"
+          ],
+          "description": "Alternative Title",
+          "applyRulesOnConcatenatedData": true
+        }
+      ]
+    }
+  ],
+  "210": [
+    {
+      "entity": [
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_alternative_title_type_id",
+                  "parameter": {
+                    "name": "Abbreviated title"
+                  }
+                }
+              ]
+            }
+          ],
+          "target": "alternativeTitles.alternativeTitleTypeId",
+          "subfield": [
+            "a",
+            "b"
+          ],
+          "description": "Alternative Title id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "remove_ending_punc, trim"
+                }
+              ]
+            }
+          ],
+          "target": "alternativeTitles.alternativeTitle",
+          "subfield": [
+            "a",
+            "b"
+          ],
+          "description": "Alternative Title",
+          "applyRulesOnConcatenatedData": true
+        }
+      ]
+    }
+  ],
+  "240": [
+    {
+      "entity": [
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_alternative_title_type_id",
+                  "parameter": {
+                    "name": "Uniform title"
+                  }
+                }
+              ]
+            }
+          ],
+          "target": "alternativeTitles.alternativeTitleTypeId",
+          "subfield": [
+            "a",
+            "n",
+            "p",
+            "d",
+            "f",
+            "g",
+            "h",
+            "k",
+            "l",
+            "m",
+            "o",
+            "r",
+            "s"
+          ],
+          "description": "Alternative Title id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "remove_ending_punc, trim"
+                }
+              ]
+            }
+          ],
+          "target": "alternativeTitles.alternativeTitle",
+          "subfield": [
+            "a",
+            "n",
+            "p",
+            "d",
+            "f",
+            "g",
+            "h",
+            "k",
+            "l",
+            "m",
+            "o",
+            "r",
+            "s"
+          ],
+          "description": "Alternative Title",
+          "applyRulesOnConcatenatedData": true
+        }
+      ]
+    }
+  ],
+  "245": [
+    {
+      "target": "title",
+      "subfield": [
+        "a",
+        "n",
+        "p",
+        "b",
+        "c",
+        "f",
+        "g",
+        "h",
+        "k",
+        "s"
+      ],
+      "description": "Resource Title",
+      "applyRulesOnConcatenatedData": true
+    },
+    {
+      "rules": [
+        {
+          "conditions": [
+            {
+              "type": "remove_prefix_by_indicator, capitalize"
+            }
+          ]
+        }
+      ],
+      "target": "indexTitle",
+      "subfield": [
+        "a",
+        "n",
+        "p",
+        "b"
+      ],
+      "description": "Index title",
+      "applyRulesOnConcatenatedData": true
+    }
+  ],
+  "246": [
+    {
+      "entity": [
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_alternative_title_type_id",
+                  "parameter": {
+                    "name": "Variant title"
+                  }
+                }
+              ]
+            }
+          ],
+          "target": "alternativeTitles.alternativeTitleTypeId",
+          "subfield": [
+            "i",
+            "a",
+            "n",
+            "p",
+            "b",
+            "f",
+            "g",
+            "h",
+            "5"
+          ],
+          "description": "Alternative Title id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "remove_ending_punc, trim"
+                }
+              ]
+            }
+          ],
+          "target": "alternativeTitles.alternativeTitle",
+          "subfield": [
+            "i",
+            "a",
+            "n",
+            "p",
+            "b",
+            "f",
+            "g",
+            "h",
+            "5"
+          ],
+          "description": "Alternative Title",
+          "applyRulesOnConcatenatedData": true
+        }
+      ]
+    }
+  ],
+  "247": [
+    {
+      "entity": [
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_alternative_title_type_id",
+                  "parameter": {
+                    "name": "Former title"
+                  }
+                }
+              ]
+            }
+          ],
+          "target": "alternativeTitles.alternativeTitleTypeId",
+          "subfield": [
+            "a",
+            "n",
+            "p",
+            "b",
+            "f",
+            "g",
+            "h",
+            "x"
+          ],
+          "description": "Alternative Title id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "remove_ending_punc, trim"
+                }
+              ]
+            }
+          ],
+          "target": "alternativeTitles.alternativeTitle",
+          "subfield": [
+            "a",
+            "n",
+            "p",
+            "b",
+            "f",
+            "g",
+            "h",
+            "x"
+          ],
+          "description": "Former title",
+          "applyRulesOnConcatenatedData": true
+        }
+      ]
+    }
+  ],
+  "250": [
+    {
+      "rules": [
+        {
+          "conditions": [
+            {
+              "type": "remove_ending_punc, trim"
+            }
+          ]
+        }
+      ],
+      "target": "editions",
+      "subfield": [
+        "a",
+        "b"
+      ],
+      "description": "Edition",
+      "applyRulesOnConcatenatedData": true
+    }
+  ],
+  "254": [
+    {
+      "rules": [
+        {
+          "conditions": [
+            {
+              "type": "remove_ending_punc, trim"
+            }
+          ]
+        }
+      ],
+      "target": "editions",
+      "subfield": [
+        "a"
+      ],
+      "description": "Edition",
+      "applyRulesOnConcatenatedData": true
+    }
+  ],
+  "255": [
+    {
+      "entity": [
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Cartographic Mathematical Data"
+                  }
+                }
+              ]
+            }
+          ],
+          "target": "notes.instanceNoteTypeId",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+            "f",
+            "g"
+          ],
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ],
+          "target": "notes.note",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+            "f",
+            "g"
+          ],
+          "description": "Cartographic Mathematical Data",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "value": "false",
+              "conditions": []
+            }
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+            "f",
+            "g"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
+        }
+      ]
+    }
+  ],
+  "260": [
+    {
+      "rules": [
+        {
+          "conditions": [
+            {
+              "type": "remove_ending_punc, trim"
+            }
+          ]
+        }
+      ],
+      "target": "publication.place",
+      "subfield": [
+        "a"
+      ],
+      "description": "Place of publication",
+      "subFieldDelimiter": [
+        {
+          "value": " ; ",
+          "subfields": [
+            "a"
+          ]
+        }
+      ]
+    },
+    {
+      "rules": [
+        {
+          "conditions": [
+            {
+              "type": "remove_ending_punc, trim"
+            }
+          ]
+        }
+      ],
+      "target": "publication.publisher",
+      "subfield": [
+        "b"
+      ],
+      "subFieldDelimiter": [
+        {
+          "value": " ; ",
+          "subfields": [
+            "b"
+          ]
+        }
+      ]
+    },
+    {
+      "rules": [
+        {
+          "conditions": [
+            {
+              "type": "remove_ending_punc, trim, trim_period"
+            }
+          ]
+        }
+      ],
+      "target": "publication.dateOfPublication",
+      "subfield": [
+        "c"
+      ],
+      "subFieldDelimiter": [
+        {
+          "value": " ; ",
+          "subfields": [
+            "c"
+          ]
+        }
+      ]
+    }
+  ],
+  "264": [
+    {
+      "rules": [
+        {
+          "conditions": [
+            {
+              "type": "remove_ending_punc, trim"
+            }
+          ]
+        }
+      ],
+      "target": "publication.place",
+      "subfield": [
+        "a"
+      ],
+      "description": "Place of publication",
+      "subFieldDelimiter": [
+        {
+          "value": " ; ",
+          "subfields": [
+            "a"
+          ]
+        }
+      ]
+    },
+    {
+      "rules": [
+        {
+          "conditions": [
+            {
+              "type": "remove_ending_punc, trim"
+            }
+          ]
+        }
+      ],
+      "target": "publication.publisher",
+      "subfield": [
+        "b"
+      ],
+      "description": "Publisher of publication",
+      "subFieldDelimiter": [
+        {
+          "value": " ; ",
+          "subfields": [
+            "b"
+          ]
+        }
+      ]
+    },
+    {
+      "rules": [
+        {
+          "conditions": [
+            {
+              "type": "remove_ending_punc, trim, trim_period"
+            }
+          ]
+        }
+      ],
+      "target": "publication.dateOfPublication",
+      "subfield": [
+        "c"
+      ],
+      "description": "Date of publication",
+      "subFieldDelimiter": [
+        {
+          "value": " ; ",
+          "subfields": [
+            "c"
+          ]
+        }
+      ]
+    },
+    {
+      "rules": [
+        {
+          "conditions": [
+            {
+              "type": "set_publisher_role"
+            }
+          ]
+        }
+      ],
+      "target": "publication.role",
+      "subfield": [
+        "a",
+        "b",
+        "c"
+      ],
+      "description": "Role of publication, defined by 2nd indicator",
+      "applyRulesOnConcatenatedData": true
+    }
+  ],
+  "300": [
+    {
+      "target": "physicalDescriptions",
+      "subfield": [
+        "a",
+        "b",
+        "c",
+        "e",
+        "f",
+        "g",
+        "3"
+      ]
+    }
+  ],
+  "310": [
+    {
+      "rules": [
+        {
+          "conditions": [
+            {
+              "type": "trim_period"
+            }
+          ]
+        }
+      ],
+      "target": "publicationFrequency",
+      "subfield": [
+        "a",
+        "b"
+      ],
+      "description": "Publication frequency",
+      "applyRulesOnConcatenatedData": true
+    }
+  ],
+  "321": [
+    {
+      "rules": [
+        {
+          "conditions": [
+            {
+              "type": "trim_period"
+            }
+          ]
+        }
+      ],
+      "target": "publicationFrequency",
+      "subfield": [
+        "a",
+        "b"
+      ],
+      "description": "Publication frequency",
+      "applyRulesOnConcatenatedData": true
+    }
+  ],
+  "336": [
+    {
+      "rules": [
+        {
+          "conditions": [
+            {
+              "type": "set_instance_type_id",
+              "parameter": {
+                "unspecifiedInstanceTypeCode": "zzz"
+              }
+            }
+          ]
+        }
+      ],
+      "target": "instanceTypeId",
+      "subfield": [
+        "a",
+        "b"
+      ],
+      "description": "Instance type ID",
+      "subFieldDelimiter": [
+        {
+          "value": "~",
+          "subfields": [
+            "a",
+            "b"
+          ]
+        }
+      ],
+      "ignoreSubsequentFields": true,
+      "ignoreSubsequentSubfields": true,
+      "applyRulesOnConcatenatedData": true
+    }
+  ],
+  "338": [
+    {
+      "rules": [
+        {
+          "conditions": [
+            {
+              "type": "set_instance_format_id"
+            }
+          ]
+        }
+      ],
+      "target": "instanceFormatIds",
+      "subfield": [
+        "b"
+      ],
+      "description": "Instance Format ID",
+      "ignoreSubsequentSubfields": true
+    }
+  ],
+  "340": [
+    {
+      "target": "physicalDescriptions",
+      "subfield": [
+        "a",
+        "b",
+        "c",
+        "d",
+        "e",
+        "f",
+        "g",
+        "h",
+        "i",
+        "j",
+        "k",
+        "l",
+        "m",
+        "n",
+        "o",
+        "p",
+        "q",
+        "3"
+      ]
+    }
+  ],
+  "344": [
+    {
+      "target": "physicalDescriptions",
+      "subfield": [
+        "a",
+        "b",
+        "c",
+        "d",
+        "e",
+        "f",
+        "g",
+        "h",
+        "i",
+        "j",
+        "3"
+      ]
+    }
+  ],
+  "347": [
+    {
+      "target": "physicalDescriptions",
+      "subfield": [
+        "a",
+        "b",
+        "c",
+        "d",
+        "e",
+        "f",
+        "3"
+      ]
+    }
+  ],
+  "348": [
+    {
+      "target": "physicalDescriptions",
+      "subfield": [
+        "a",
+        "b",
+        "c",
+        "d",
+        "3"
+      ]
+    }
+  ],
+  "362": [
+    {
+      "rules": [
+        {
+          "conditions": [
+            {
+              "type": "trim_period"
+            }
+          ]
+        }
+      ],
+      "target": "publicationRange",
+      "subfield": [
+        "a",
+        "z"
+      ],
+      "description": "Publication range",
+      "applyRulesOnConcatenatedData": true
+    }
+  ],
+  "382": [
+    {
+      "entity": [
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Music details note"
+                  }
+                }
+              ]
+            }
+          ],
+          "target": "notes.instanceNoteTypeId",
+          "subfield": [
+            "a",
+            "b",
+            "d",
+            "e",
+            "n",
+            "p",
+            "r",
+            "s",
+            "t",
+            "v",
+            "3"
+          ],
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ],
+          "target": "notes.note",
+          "subfield": [
+            "a",
+            "b",
+            "d",
+            "e",
+            "n",
+            "p",
+            "r",
+            "s",
+            "t",
+            "v",
+            "3"
+          ],
+          "description": "Music details note",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "value": "false",
+              "conditions": []
+            }
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a",
+            "b",
+            "d",
+            "e",
+            "n",
+            "p",
+            "r",
+            "s",
+            "t",
+            "v",
+            "3"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
+        }
+      ]
+    }
+  ],
+  "383": [
+    {
+      "entity": [
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Music details note"
+                  }
+                }
+              ]
+            }
+          ],
+          "target": "notes.instanceNoteTypeId",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+            "3"
+          ],
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ],
+          "target": "notes.note",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+            "3"
+          ],
+          "description": "Music details note",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "value": "false",
+              "conditions": []
+            }
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+            "3"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
+        }
+      ]
+    }
+  ],
+  "384": [
+    {
+      "entity": [
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Music details note"
+                  }
+                }
+              ]
+            }
+          ],
+          "target": "notes.instanceNoteTypeId",
+          "subfield": [
+            "a",
+            "3"
+          ],
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ],
+          "target": "notes.note",
+          "subfield": [
+            "a",
+            "3"
+          ],
+          "description": "Music details note",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "value": "false",
+              "conditions": []
+            }
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a",
+            "3"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
+        }
+      ]
+    }
+  ],
+  "500": [
+    {
+      "entity": [
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "General note"
+                  }
+                }
+              ]
+            }
+          ],
+          "target": "notes.instanceNoteTypeId",
+          "subfield": [
+            "a",
+            "3",
+            "5"
+          ],
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ],
+          "target": "notes.note",
+          "subfield": [
+            "a",
+            "3",
+            "5"
+          ],
+          "description": "General Note",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "value": "false",
+              "conditions": []
+            }
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a",
+            "3",
+            "5"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
+        }
+      ]
+    }
+  ],
+  "501": [
+    {
+      "entity": [
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "With note"
+                  }
+                }
+              ]
+            }
+          ],
+          "target": "notes.instanceNoteTypeId",
+          "subfield": [
+            "a",
+            "5"
+          ],
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ],
+          "target": "notes.note",
+          "subfield": [
+            "a",
+            "5"
+          ],
+          "description": "With Note",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "value": "false",
+              "conditions": []
+            }
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a",
+            "5"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
+        }
+      ]
+    }
+  ],
+  "502": [
+    {
+      "entity": [
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Dissertation note"
+                  }
+                }
+              ]
+            }
+          ],
+          "target": "notes.instanceNoteTypeId",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "g",
+            "o"
+          ],
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ],
+          "target": "notes.note",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "g",
+            "o"
+          ],
+          "description": "Dissertation Note",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "value": "false",
+              "conditions": []
+            }
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "g",
+            "o"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
+        }
+      ]
+    }
+  ],
+  "504": [
+    {
+      "entity": [
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Bibliography note"
+                  }
+                }
+              ]
+            }
+          ],
+          "target": "notes.instanceNoteTypeId",
+          "subfield": [
+            "a",
+            "b"
+          ],
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ],
+          "target": "notes.note",
+          "subfield": [
+            "a",
+            "b"
+          ],
+          "description": "Bibliography, etc. Note",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "value": "false",
+              "conditions": []
+            }
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a",
+            "b"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
+        }
+      ]
+    }
+  ],
+  "505": [
+    {
+      "entity": [
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Formatted Contents Note"
+                  }
+                }
+              ]
+            }
+          ],
+          "target": "notes.instanceNoteTypeId",
+          "subfield": [
+            "a",
+            "g",
+            "r",
+            "t",
+            "u"
+          ],
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ],
+          "target": "notes.note",
+          "subfield": [
+            "a",
+            "g",
+            "r",
+            "t",
+            "u"
+          ],
+          "description": "Formatted Contents Note",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "value": "false",
+              "conditions": []
+            }
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a",
+            "g",
+            "r",
+            "t",
+            "u"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
+        }
+      ]
+    }
+  ],
+  "506": [
+    {
+      "entity": [
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Restrictions on Access note"
+                  }
+                }
+              ]
+            }
+          ],
+          "target": "notes.instanceNoteTypeId",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+            "f",
+            "u",
+            "2",
+            "3",
+            "5"
+          ],
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ],
+          "target": "notes.note",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+            "f",
+            "u",
+            "2",
+            "3",
+            "5"
+          ],
+          "description": "Restrictions on Access Note",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "value": "false",
+              "conditions": []
+            }
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+            "f",
+            "u",
+            "2",
+            "3",
+            "5"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
+        }
+      ]
+    }
+  ],
+  "507": [
+    {
+      "entity": [
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Scale note for graphic material"
+                  }
+                }
+              ]
+            }
+          ],
+          "target": "notes.instanceNoteTypeId",
+          "subfield": [
+            "a",
+            "b"
+          ],
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ],
+          "target": "notes.note",
+          "subfield": [
+            "a",
+            "b"
+          ],
+          "description": "Scale Note for Graphic Material",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "value": "false",
+              "conditions": []
+            }
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a",
+            "b"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
+        }
+      ]
+    }
+  ],
+  "508": [
+    {
+      "entity": [
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Creation / Production Credits note"
+                  }
+                }
+              ]
+            }
+          ],
+          "target": "notes.instanceNoteTypeId",
+          "subfield": [
+            "a"
+          ],
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ],
+          "target": "notes.note",
+          "subfield": [
+            "a"
+          ],
+          "description": "Creation/Production Credits Note",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "value": "false",
+              "conditions": []
+            }
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
+        }
+      ]
+    }
+  ],
+  "510": [
+    {
+      "entity": [
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Citation / References note"
+                  }
+                }
+              ]
+            }
+          ],
+          "target": "notes.instanceNoteTypeId",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "u",
+            "x",
+            "3"
+          ],
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ],
+          "target": "notes.note",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "u",
+            "x",
+            "3"
+          ],
+          "description": "Citation/References Note",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "value": "false",
+              "conditions": []
+            }
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "u",
+            "x",
+            "3"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
+        }
+      ]
+    }
+  ],
+  "511": [
+    {
+      "entity": [
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Participant or Performer note"
+                  }
+                }
+              ]
+            }
+          ],
+          "target": "notes.instanceNoteTypeId",
+          "subfield": [
+            "a"
+          ],
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ],
+          "target": "notes.note",
+          "subfield": [
+            "a"
+          ],
+          "description": "Participant or Performer Note",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "value": "false",
+              "conditions": []
+            }
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
+        }
+      ]
+    }
+  ],
+  "513": [
+    {
+      "entity": [
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Type of report and period covered note"
+                  }
+                }
+              ]
+            }
+          ],
+          "target": "notes.instanceNoteTypeId",
+          "subfield": [
+            "a",
+            "b"
+          ],
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ],
+          "target": "notes.note",
+          "subfield": [
+            "a",
+            "b"
+          ],
+          "description": "Type of Report and Period Covered Note",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "value": "false",
+              "conditions": []
+            }
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a",
+            "b"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
+        }
+      ]
+    }
+  ],
+  "514": [
+    {
+      "entity": [
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Data quality note"
+                  }
+                }
+              ]
+            }
+          ],
+          "target": "notes.instanceNoteTypeId",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+            "f",
+            "g",
+            "h",
+            "i",
+            "j",
+            "k",
+            "m",
+            "u",
+            "z"
+          ],
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ],
+          "target": "notes.note",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+            "f",
+            "g",
+            "h",
+            "i",
+            "j",
+            "k",
+            "m",
+            "u",
+            "z"
+          ],
+          "description": "Data Quality Note",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "value": "false",
+              "conditions": []
+            }
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+            "f",
+            "g",
+            "h",
+            "i",
+            "j",
+            "k",
+            "m",
+            "u",
+            "z"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
+        }
+      ]
+    }
+  ],
+  "515": [
+    {
+      "entity": [
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Numbering peculiarities note"
+                  }
+                }
+              ]
+            }
+          ],
+          "target": "notes.instanceNoteTypeId",
+          "subfield": [
+            "a"
+          ],
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ],
+          "target": "notes.note",
+          "subfield": [
+            "a"
+          ],
+          "description": "Numbering Peculiarities Note",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "value": "false",
+              "conditions": []
+            }
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
+        }
+      ]
+    }
+  ],
+  "516": [
+    {
+      "entity": [
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Type of computer file or data note"
+                  }
+                }
+              ]
+            }
+          ],
+          "target": "notes.instanceNoteTypeId",
+          "subfield": [
+            "a"
+          ],
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ],
+          "target": "notes.note",
+          "subfield": [
+            "a"
+          ],
+          "description": "Type of Computer File or Data Note",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "value": "false",
+              "conditions": []
+            }
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
+        }
+      ]
+    }
+  ],
+  "518": [
+    {
+      "entity": [
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Date / time and place of an event note"
+                  }
+                }
+              ]
+            }
+          ],
+          "target": "notes.instanceNoteTypeId",
+          "subfield": [
+            "a",
+            "d",
+            "o",
+            "p",
+            "2",
+            "3"
+          ],
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ],
+          "target": "notes.note",
+          "subfield": [
+            "a",
+            "d",
+            "o",
+            "p",
+            "2",
+            "3"
+          ],
+          "description": "Date/Time and Place of an Event Note",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "value": "false",
+              "conditions": []
+            }
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a",
+            "d",
+            "o",
+            "p",
+            "2",
+            "3"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
+        }
+      ]
+    }
+  ],
+  "520": [
+    {
+      "entity": [
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Summary"
+                  }
+                }
+              ]
+            }
+          ],
+          "target": "notes.instanceNoteTypeId",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "u",
+            "2",
+            "3"
+          ],
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ],
+          "target": "notes.note",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "u",
+            "2",
+            "3"
+          ],
+          "description": "Summary, Etc.",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "value": "false",
+              "conditions": []
+            }
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "u",
+            "2",
+            "3"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
+        }
+      ]
+    }
+  ],
+  "521": [
+    {
+      "entity": [
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Target Audience note"
+                  }
+                }
+              ]
+            }
+          ],
+          "target": "notes.instanceNoteTypeId",
+          "subfield": [
+            "a",
+            "b",
+            "3"
+          ],
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ],
+          "target": "notes.note",
+          "subfield": [
+            "a",
+            "b",
+            "3"
+          ],
+          "description": "Target Audience Note",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "value": "false",
+              "conditions": []
+            }
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a",
+            "b",
+            "3"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
+        }
+      ]
+    }
+  ],
+  "522": [
+    {
+      "entity": [
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Geographic Coverage note"
+                  }
+                }
+              ]
+            }
+          ],
+          "target": "notes.instanceNoteTypeId",
+          "subfield": [
+            "a"
+          ],
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ],
+          "target": "notes.note",
+          "subfield": [
+            "a"
+          ],
+          "description": "Geographic Coverage Note",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "value": "false",
+              "conditions": []
+            }
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
+        }
+      ]
+    }
+  ],
+  "524": [
+    {
+      "entity": [
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Preferred Citation of Described Materials note"
+                  }
+                }
+              ]
+            }
+          ],
+          "target": "notes.instanceNoteTypeId",
+          "subfield": [
+            "a",
+            "2",
+            "3"
+          ],
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ],
+          "target": "notes.note",
+          "subfield": [
+            "a",
+            "2",
+            "3"
+          ],
+          "description": "Preferred Citation of Described Materials Note",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "value": "false",
+              "conditions": []
+            }
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a",
+            "2",
+            "3"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
+        }
+      ]
+    }
+  ],
+  "525": [
+    {
+      "entity": [
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Supplement note"
+                  }
+                }
+              ]
+            }
+          ],
+          "target": "notes.instanceNoteTypeId",
+          "subfield": [
+            "a"
+          ],
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ],
+          "target": "notes.note",
+          "subfield": [
+            "a"
+          ],
+          "description": "Supplement Note",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "value": "false",
+              "conditions": []
+            }
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
+        }
+      ]
+    }
+  ],
+  "526": [
+    {
+      "entity": [
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Study Program Information note"
+                  }
+                }
+              ]
+            }
+          ],
+          "target": "notes.instanceNoteTypeId",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "5",
+            "x",
+            "z"
+          ],
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ],
+          "target": "notes.note",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "5",
+            "x",
+            "z"
+          ],
+          "description": "Study Program Information Note",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "value": "false",
+              "conditions": []
+            }
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "5",
+            "x",
+            "z"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
+        }
+      ]
+    }
+  ],
+  "530": [
+    {
+      "entity": [
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Additional Physical Form Available note"
+                  }
+                }
+              ]
+            }
+          ],
+          "target": "notes.instanceNoteTypeId",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "u",
+            "3"
+          ],
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ],
+          "target": "notes.note",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "u",
+            "3"
+          ],
+          "description": "Additional Physical Form Available Note",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "value": "false",
+              "conditions": []
+            }
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "u",
+            "3"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
+        }
+      ]
+    }
+  ],
+  "532": [
+    {
+      "entity": [
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Accessibility note"
+                  }
+                }
+              ]
+            }
+          ],
+          "target": "notes.instanceNoteTypeId",
+          "subfield": [
+            "a"
+          ],
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ],
+          "target": "notes.note",
+          "subfield": [
+            "a"
+          ],
+          "description": "Accessibility note",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "value": "false",
+              "conditions": []
+            }
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
+        }
+      ]
+    }
+  ],
+  "533": [
+    {
+      "entity": [
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Reproduction note"
+                  }
+                }
+              ]
+            }
+          ],
+          "target": "notes.instanceNoteTypeId",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+            "f",
+            "m",
+            "n",
+            "3",
+            "5"
+          ],
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ],
+          "target": "notes.note",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+            "f",
+            "m",
+            "n",
+            "3",
+            "5"
+          ],
+          "description": "Reproduction Note",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "value": "false",
+              "conditions": []
+            }
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+            "f",
+            "m",
+            "n",
+            "3",
+            "5"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
+        }
+      ]
+    }
+  ],
+  "534": [
+    {
+      "entity": [
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Original Version note"
+                  }
+                }
+              ]
+            }
+          ],
+          "target": "notes.instanceNoteTypeId",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "e",
+            "f",
+            "k",
+            "l",
+            "m",
+            "n",
+            "o",
+            "p",
+            "t",
+            "x",
+            "z",
+            "3"
+          ],
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ],
+          "target": "notes.note",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "e",
+            "f",
+            "k",
+            "l",
+            "m",
+            "n",
+            "o",
+            "p",
+            "t",
+            "x",
+            "z",
+            "3"
+          ],
+          "description": "Original Version Note",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "value": "false",
+              "conditions": []
+            }
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "e",
+            "f",
+            "k",
+            "l",
+            "m",
+            "n",
+            "o",
+            "p",
+            "t",
+            "x",
+            "z",
+            "3"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
+        }
+      ]
+    }
+  ],
+  "535": [
+    {
+      "entity": [
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Location of Originals / Duplicates note"
+                  }
+                }
+              ]
+            }
+          ],
+          "target": "notes.instanceNoteTypeId",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "g",
+            "3"
+          ],
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ],
+          "target": "notes.note",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "g",
+            "3"
+          ],
+          "description": "Location of Originals/Duplicates Note",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "value": "false",
+              "conditions": []
+            }
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "g",
+            "3"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
+        }
+      ]
+    }
+  ],
+  "536": [
+    {
+      "entity": [
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Funding Information Note"
+                  }
+                }
+              ]
+            }
+          ],
+          "target": "notes.instanceNoteTypeId",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+            "f",
+            "g",
+            "h"
+          ],
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ],
+          "target": "notes.note",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+            "f",
+            "g",
+            "h"
+          ],
+          "description": "Funding Information Note",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "value": "false",
+              "conditions": []
+            }
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+            "f",
+            "g",
+            "h"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
+        }
+      ]
+    }
+  ],
+  "538": [
+    {
+      "entity": [
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "System Details note"
+                  }
+                }
+              ]
+            }
+          ],
+          "target": "notes.instanceNoteTypeId",
+          "subfield": [
+            "a",
+            "u",
+            "3",
+            "5"
+          ],
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ],
+          "target": "notes.note",
+          "subfield": [
+            "a",
+            "u",
+            "3",
+            "5"
+          ],
+          "description": "System Details Note",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "value": "false",
+              "conditions": []
+            }
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a",
+            "u",
+            "3",
+            "5"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
+        }
+      ]
+    }
+  ],
+  "540": [
+    {
+      "entity": [
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Terms Governing Use and Reproduction note"
+                  }
+                }
+              ]
+            }
+          ],
+          "target": "notes.instanceNoteTypeId",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "u",
+            "3",
+            "5"
+          ],
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ],
+          "target": "notes.note",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "u",
+            "3",
+            "5"
+          ],
+          "description": "Terms Governing Use and Reproduction Note",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "value": "false",
+              "conditions": []
+            }
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "u",
+            "3",
+            "5"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
+        }
+      ]
+    }
+  ],
+  "541": [
+    {
+      "entity": [
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Immediate Source of Acquisition note"
+                  }
+                }
+              ]
+            }
+          ],
+          "target": "notes.instanceNoteTypeId",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+            "f",
+            "h",
+            "n",
+            "o",
+            "3",
+            "5"
+          ],
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ],
+          "target": "notes.note",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+            "f",
+            "h",
+            "n",
+            "o",
+            "3",
+            "5"
+          ],
+          "description": "Immediate Source of Acquisition Note",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_staff_only_via_indicator"
+                }
+              ]
+            }
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+            "f",
+            "h",
+            "n",
+            "o",
+            "3",
+            "5"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff",
+          "applyRulesOnConcatenatedData": true
+        }
+      ]
+    }
+  ],
+  "542": [
+    {
+      "entity": [
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Information related to Copyright Status"
+                  }
+                }
+              ]
+            }
+          ],
+          "target": "notes.instanceNoteTypeId",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+            "f",
+            "g",
+            "h",
+            "i",
+            "j",
+            "k",
+            "l",
+            "m",
+            "n",
+            "o",
+            "p",
+            "q",
+            "r",
+            "s",
+            "u",
+            "3"
+          ],
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ],
+          "target": "notes.note",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+            "f",
+            "g",
+            "h",
+            "i",
+            "j",
+            "k",
+            "l",
+            "m",
+            "n",
+            "o",
+            "p",
+            "q",
+            "r",
+            "s",
+            "u",
+            "3"
+          ],
+          "description": "Information Relating to Copyright Status",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_staff_only_via_indicator"
+                }
+              ]
+            }
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+            "f",
+            "g",
+            "h",
+            "i",
+            "j",
+            "k",
+            "l",
+            "m",
+            "n",
+            "o",
+            "p",
+            "q",
+            "r",
+            "s",
+            "u",
+            "3"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff",
+          "applyRulesOnConcatenatedData": true
+        }
+      ]
+    }
+  ],
+  "544": [
+    {
+      "entity": [
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Location of Other Archival Materials note"
+                  }
+                }
+              ]
+            }
+          ],
+          "target": "notes.instanceNoteTypeId",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+            "n",
+            "3"
+          ],
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ],
+          "target": "notes.note",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+            "n",
+            "3"
+          ],
+          "description": "Location of Other Archival Materials Note",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "value": "false",
+              "conditions": []
+            }
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+            "n",
+            "3"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
+        }
+      ]
+    }
+  ],
+  "545": [
+    {
+      "entity": [
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Biographical or Historical Data"
+                  }
+                }
+              ]
+            }
+          ],
+          "target": "notes.instanceNoteTypeId",
+          "subfield": [
+            "a",
+            "b",
+            "u"
+          ],
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ],
+          "target": "notes.note",
+          "subfield": [
+            "a",
+            "b",
+            "u"
+          ],
+          "description": "Biographical or Historical Data",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "value": "false",
+              "conditions": []
+            }
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a",
+            "b",
+            "u"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
+        }
+      ]
+    }
+  ],
+  "546": [
+    {
+      "entity": [
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Language note"
+                  }
+                }
+              ]
+            }
+          ],
+          "target": "notes.instanceNoteTypeId",
+          "subfield": [
+            "a",
+            "b",
+            "3"
+          ],
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ],
+          "target": "notes.note",
+          "subfield": [
+            "a",
+            "b",
+            "3"
+          ],
+          "description": "Language Note",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "value": "false",
+              "conditions": []
+            }
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a",
+            "b",
+            "3"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
+        }
+      ]
+    }
+  ],
+  "547": [
+    {
+      "entity": [
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Former Title Complexity note"
+                  }
+                }
+              ]
+            }
+          ],
+          "target": "notes.instanceNoteTypeId",
+          "subfield": [
+            "a"
+          ],
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ],
+          "target": "notes.note",
+          "subfield": [
+            "a"
+          ],
+          "description": "Former Title Complexity Note",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "value": "false",
+              "conditions": []
+            }
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
+        }
+      ]
+    }
+  ],
+  "550": [
+    {
+      "entity": [
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Issuing Body note"
+                  }
+                }
+              ]
+            }
+          ],
+          "target": "notes.instanceNoteTypeId",
+          "subfield": [
+            "a"
+          ],
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ],
+          "target": "notes.note",
+          "subfield": [
+            "a"
+          ],
+          "description": "Issuing Body Note",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "value": "false",
+              "conditions": []
+            }
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
+        }
+      ]
+    }
+  ],
+  "552": [
+    {
+      "entity": [
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Entity and Attribute Information note"
+                  }
+                }
+              ]
+            }
+          ],
+          "target": "notes.instanceNoteTypeId",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+            "f",
+            "g",
+            "h",
+            "i",
+            "j",
+            "k",
+            "l",
+            "m",
+            "n",
+            "o",
+            "p",
+            "u",
+            "z"
+          ],
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ],
+          "target": "notes.note",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+            "f",
+            "g",
+            "h",
+            "i",
+            "j",
+            "k",
+            "l",
+            "m",
+            "n",
+            "o",
+            "p",
+            "u",
+            "z"
+          ],
+          "description": "Entity and Attribute Information Note",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "value": "false",
+              "conditions": []
+            }
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+            "f",
+            "g",
+            "h",
+            "i",
+            "j",
+            "k",
+            "l",
+            "m",
+            "n",
+            "o",
+            "p",
+            "u",
+            "z"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
+        }
+      ]
+    }
+  ],
+  "555": [
+    {
+      "entity": [
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Cumulative Index / Finding Aides notes"
+                  }
+                }
+              ]
+            }
+          ],
+          "target": "notes.instanceNoteTypeId",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "u",
+            "3"
+          ],
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ],
+          "target": "notes.note",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "u",
+            "3"
+          ],
+          "description": "Cumulative Index/Finding Aids Note",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "value": "false",
+              "conditions": []
+            }
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "u",
+            "3"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
+        }
+      ]
+    }
+  ],
+  "556": [
+    {
+      "entity": [
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Information About Documentation note"
+                  }
+                }
+              ]
+            }
+          ],
+          "target": "notes.instanceNoteTypeId",
+          "subfield": [
+            "a",
+            "z"
+          ],
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ],
+          "target": "notes.note",
+          "subfield": [
+            "a",
+            "z"
+          ],
+          "description": "Information About Documentation Note",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "value": "false",
+              "conditions": []
+            }
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a",
+            "z"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
+        }
+      ]
+    }
+  ],
+  "561": [
+    {
+      "entity": [
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Ownership and Custodial History note"
+                  }
+                }
+              ]
+            }
+          ],
+          "target": "notes.instanceNoteTypeId",
+          "subfield": [
+            "a",
+            "u",
+            "3",
+            "5"
+          ],
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ],
+          "target": "notes.note",
+          "subfield": [
+            "a",
+            "u",
+            "3",
+            "5"
+          ],
+          "description": "Ownership and Custodial History",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_staff_only_via_indicator"
+                }
+              ]
+            }
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a",
+            "u",
+            "3",
+            "5"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff",
+          "applyRulesOnConcatenatedData": true
+        }
+      ]
+    }
+  ],
+  "562": [
+    {
+      "entity": [
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Copy and Version Identification note"
+                  }
+                }
+              ]
+            }
+          ],
+          "target": "notes.instanceNoteTypeId",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+            "3",
+            "5"
+          ],
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ],
+          "target": "notes.note",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+            "3",
+            "5"
+          ],
+          "description": "Copy and Version Identification Note",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "value": "false",
+              "conditions": []
+            }
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+            "3",
+            "5"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
+        }
+      ]
+    }
+  ],
+  "563": [
+    {
+      "entity": [
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Binding Information note"
+                  }
+                }
+              ]
+            }
+          ],
+          "target": "notes.instanceNoteTypeId",
+          "subfield": [
+            "a",
+            "u",
+            "3",
+            "5"
+          ],
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ],
+          "target": "notes.note",
+          "subfield": [
+            "a",
+            "u",
+            "3",
+            "5"
+          ],
+          "description": "Binding Information",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "value": "false",
+              "conditions": []
+            }
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a",
+            "u",
+            "3",
+            "5"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
+        }
+      ]
+    }
+  ],
+  "565": [
+    {
+      "entity": [
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Case File Characteristics note"
+                  }
+                }
+              ]
+            }
+          ],
+          "target": "notes.instanceNoteTypeId",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+            "3"
+          ],
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ],
+          "target": "notes.note",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+            "3"
+          ],
+          "description": "Case File Characteristics Note",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "value": "false",
+              "conditions": []
+            }
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+            "3"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
+        }
+      ]
+    }
+  ],
+  "567": [
+    {
+      "entity": [
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Methodology note"
+                  }
+                }
+              ]
+            }
+          ],
+          "target": "notes.instanceNoteTypeId",
+          "subfield": [
+            "a",
+            "b",
+            "2"
+          ],
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ],
+          "target": "notes.note",
+          "subfield": [
+            "a",
+            "b",
+            "2"
+          ],
+          "description": "Methodology Note",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "value": "false",
+              "conditions": []
+            }
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a",
+            "b",
+            "2"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
+        }
+      ]
+    }
+  ],
+  "580": [
+    {
+      "entity": [
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Linking Entry Complexity note"
+                  }
+                }
+              ]
+            }
+          ],
+          "target": "notes.instanceNoteTypeId",
+          "subfield": [
+            "a"
+          ],
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ],
+          "target": "notes.note",
+          "subfield": [
+            "a"
+          ],
+          "description": "Linking Entry Complexity Note",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "value": "false",
+              "conditions": []
+            }
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
+        }
+      ]
+    }
+  ],
+  "581": [
+    {
+      "entity": [
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Publications About Described Materials note"
+                  }
+                }
+              ]
+            }
+          ],
+          "target": "notes.instanceNoteTypeId",
+          "subfield": [
+            "a",
+            "z",
+            "3"
+          ],
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ],
+          "target": "notes.note",
+          "subfield": [
+            "a",
+            "z",
+            "3"
+          ],
+          "description": "Publications About Described Materials Note",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "value": "false",
+              "conditions": []
+            }
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a",
+            "z",
+            "3"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
+        }
+      ]
+    }
+  ],
+  "583": [
+    {
+      "entity": [
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Action note"
+                  }
+                }
+              ]
+            }
+          ],
+          "target": "notes.instanceNoteTypeId",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+            "f",
+            "h",
+            "i",
+            "j",
+            "k",
+            "l",
+            "n",
+            "o",
+            "u",
+            "x",
+            "z",
+            "2",
+            "3",
+            "5"
+          ],
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ],
+          "target": "notes.note",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+            "f",
+            "h",
+            "i",
+            "j",
+            "k",
+            "l",
+            "n",
+            "o",
+            "u",
+            "x",
+            "z",
+            "2",
+            "3",
+            "5"
+          ],
+          "description": "Action Note",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_staff_only_via_indicator"
+                }
+              ]
+            }
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+            "f",
+            "h",
+            "i",
+            "j",
+            "k",
+            "l",
+            "n",
+            "o",
+            "u",
+            "x",
+            "z",
+            "2",
+            "3",
+            "5"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff",
+          "applyRulesOnConcatenatedData": true
+        }
+      ]
+    }
+  ],
+  "584": [
+    {
+      "entity": [
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Accumulation and Frequency of Use note"
+                  }
+                }
+              ]
+            }
+          ],
+          "target": "notes.instanceNoteTypeId",
+          "subfield": [
+            "a",
+            "b",
+            "3",
+            "5"
+          ],
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ],
+          "target": "notes.note",
+          "subfield": [
+            "a",
+            "b",
+            "3",
+            "5"
+          ],
+          "description": "Accumulation and Frequency of Use Note",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "value": "false",
+              "conditions": []
+            }
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a",
+            "b",
+            "3",
+            "5"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
+        }
+      ]
+    }
+  ],
+  "585": [
+    {
+      "entity": [
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Exhibitions note"
+                  }
+                }
+              ]
+            }
+          ],
+          "target": "notes.instanceNoteTypeId",
+          "subfield": [
+            "a",
+            "3",
+            "5"
+          ],
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ],
+          "target": "notes.note",
+          "subfield": [
+            "a",
+            "3",
+            "5"
+          ],
+          "description": "Exhibitions Note",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "value": "false",
+              "conditions": []
+            }
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a",
+            "3",
+            "5"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
+        }
+      ]
+    }
+  ],
+  "586": [
+    {
+      "entity": [
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Awards note"
+                  }
+                }
+              ]
+            }
+          ],
+          "target": "notes.instanceNoteTypeId",
+          "subfield": [
+            "a",
+            "3"
+          ],
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ],
+          "target": "notes.note",
+          "subfield": [
+            "a",
+            "3"
+          ],
+          "description": "Awards Note",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "value": "false",
+              "conditions": []
+            }
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a",
+            "3"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
+        }
+      ]
+    }
+  ],
+  "588": [
+    {
+      "entity": [
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Source of Description note"
+                  }
+                }
+              ]
+            }
+          ],
+          "target": "notes.instanceNoteTypeId",
+          "subfield": [
+            "a",
+            "5"
+          ],
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ],
+          "target": "notes.note",
+          "subfield": [
+            "a",
+            "5"
+          ],
+          "description": "Source of Description Note",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "value": "false",
+              "conditions": []
+            }
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a",
+            "5"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
+        }
+      ]
+    }
+  ],
+  "590": [
+    {
+      "entity": [
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Local notes"
+                  }
+                }
+              ]
+            }
+          ],
+          "target": "notes.instanceNoteTypeId",
+          "subfield": [
+            "a"
+          ],
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ],
+          "target": "notes.note",
+          "subfield": [
+            "a"
+          ],
+          "description": "Local notes",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_staff_only_via_indicator"
+                }
+              ]
+            }
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a"
+          ],
+          "description": "If the 1st indicator equals 0, determines that the note should not be visible for others than staff"
+        }
+      ]
+    }
+  ],
+  "600": [
+    {
+      "rules": [
+        {
+          "conditions": [
+            {
+              "type": "trim_period, trim"
+            }
+          ]
+        }
+      ],
+      "target": "subjects",
+      "subfield": [
+        "a",
+        "b",
+        "c",
+        "d",
+        "e",
+        "f",
+        "g",
+        "h",
+        "j",
+        "k",
+        "l",
+        "m",
+        "n",
+        "o",
+        "p",
+        "q",
+        "r",
+        "s",
+        "t",
+        "u",
+        "v",
+        "x",
+        "y",
+        "z"
+      ],
+      "description": "Subject Headings",
+      "subFieldDelimiter": [
+        {
+          "value": " ",
+          "subfields": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "j",
+            "q",
+            "t",
+            "f",
+            "g",
+            "k",
+            "l",
+            "m",
+            "n",
+            "o",
+            "p",
+            "r",
+            "s"
+          ]
+        },
+        {
+          "value": "--",
+          "subfields": [
+            "x",
+            "y",
+            "z",
+            "v"
+          ]
+        },
+        {
+          "value": "--",
+          "subfields": []
+        }
+      ],
+      "applyRulesOnConcatenatedData": true
+    }
+  ],
+  "610": [
+    {
+      "rules": [
+        {
+          "conditions": [
+            {
+              "type": "trim_period, trim"
+            }
+          ]
+        }
+      ],
+      "target": "subjects",
+      "subfield": [
+        "a",
+        "b",
+        "c",
+        "d",
+        "e",
+        "f",
+        "g",
+        "h",
+        "k",
+        "l",
+        "m",
+        "n",
+        "o",
+        "p",
+        "r",
+        "s",
+        "t",
+        "u",
+        "v",
+        "x",
+        "y",
+        "z"
+      ],
+      "description": "Subject Headings",
+      "subFieldDelimiter": [
+        {
+          "value": " ",
+          "subfields": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "t",
+            "f",
+            "g",
+            "k",
+            "l",
+            "m",
+            "n",
+            "o",
+            "p",
+            "s"
+          ]
+        },
+        {
+          "value": "--",
+          "subfields": [
+            "x",
+            "y",
+            "z",
+            "v"
+          ]
+        },
+        {
+          "value": "--",
+          "subfields": []
+        }
+      ],
+      "applyRulesOnConcatenatedData": true
+    }
+  ],
+  "611": [
+    {
+      "rules": [
+        {
+          "conditions": [
+            {
+              "type": "trim_period, trim"
+            }
+          ]
+        }
+      ],
+      "target": "subjects",
+      "subfield": [
+        "a",
+        "c",
+        "d",
+        "e",
+        "f",
+        "g",
+        "h",
+        "j",
+        "k",
+        "l",
+        "n",
+        "p",
+        "q",
+        "s",
+        "t",
+        "u",
+        "v",
+        "x",
+        "y",
+        "z"
+      ],
+      "description": "Subject Headings",
+      "subFieldDelimiter": [
+        {
+          "value": " ",
+          "subfields": [
+            "a",
+            "c",
+            "d",
+            "e",
+            "q",
+            "t",
+            "f",
+            "g",
+            "k",
+            "l",
+            "m",
+            "n",
+            "o",
+            "p",
+            "r",
+            "s"
+          ]
+        },
+        {
+          "value": "--",
+          "subfields": [
+            "x",
+            "y",
+            "z",
+            "v"
+          ]
+        },
+        {
+          "value": "--",
+          "subfields": []
+        }
+      ],
+      "applyRulesOnConcatenatedData": true
+    }
+  ],
+  "630": [
+    {
+      "rules": [
+        {
+          "conditions": [
+            {
+              "type": "trim_period, trim"
+            }
+          ]
+        }
+      ],
+      "target": "subjects",
+      "subfield": [
+        "a",
+        "d",
+        "e",
+        "f",
+        "g",
+        "h",
+        "k",
+        "l",
+        "m",
+        "n",
+        "o",
+        "p",
+        "r",
+        "s",
+        "t",
+        "v",
+        "x",
+        "y",
+        "z"
+      ],
+      "description": "Subject Headings",
+      "subFieldDelimiter": [
+        {
+          "value": " ",
+          "subfields": [
+            "a",
+            "d",
+            "f",
+            "g",
+            "k",
+            "l",
+            "m",
+            "n",
+            "o",
+            "p",
+            "r",
+            "s"
+          ]
+        },
+        {
+          "value": "--",
+          "subfields": [
+            "x",
+            "y",
+            "z",
+            "v"
+          ]
+        },
+        {
+          "value": "--",
+          "subfields": []
+        }
+      ],
+      "applyRulesOnConcatenatedData": true
+    }
+  ],
+  "647": [
+    {
+      "rules": [
+        {
+          "conditions": [
+            {
+              "type": "trim_period, trim"
+            }
+          ]
+        }
+      ],
+      "target": "subjects",
+      "subfield": [
+        "a",
+        "c",
+        "d",
+        "g",
+        "x",
+        "y",
+        "z",
+        "v"
+      ],
+      "description": "Subject Headings",
+      "subFieldDelimiter": [
+        {
+          "value": "--",
+          "subfields": [
+            "a",
+            "c",
+            "d",
+            "g",
+            "x",
+            "y",
+            "z",
+            "v"
+          ]
+        },
+        {
+          "value": "--",
+          "subfields": []
+        }
+      ],
+      "applyRulesOnConcatenatedData": true
+    }
+  ],
+  "648": [
+    {
+      "rules": [
+        {
+          "conditions": [
+            {
+              "type": "trim_period, trim"
+            }
+          ]
+        }
+      ],
+      "target": "subjects",
+      "subfield": [
+        "a",
+        "x",
+        "y",
+        "z",
+        "v"
+      ],
+      "description": "Subject Headings",
+      "subFieldDelimiter": [
+        {
+          "value": "--",
+          "subfields": [
+            "a",
+            "x",
+            "y",
+            "z",
+            "v"
+          ]
+        }
+      ],
+      "applyRulesOnConcatenatedData": true
+    }
+  ],
+  "650": [
+    {
+      "rules": [
+        {
+          "conditions": [
+            {
+              "type": "trim_period, trim"
+            }
+          ]
+        }
+      ],
+      "target": "subjects",
+      "subfield": [
+        "a",
+        "b",
+        "c",
+        "d",
+        "e",
+        "g",
+        "v",
+        "x",
+        "y",
+        "z"
+      ],
+      "description": "Subject Headings",
+      "subFieldDelimiter": [
+        {
+          "value": "--",
+          "subfields": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+            "g",
+            "v",
+            "x",
+            "y",
+            "z"
+          ]
+        }
+      ],
+      "applyRulesOnConcatenatedData": true
+    }
+  ],
+  "651": [
+    {
+      "rules": [
+        {
+          "conditions": [
+            {
+              "type": "trim_period, trim"
+            }
+          ]
+        }
+      ],
+      "target": "subjects",
+      "subfield": [
+        "a",
+        "e",
+        "g",
+        "v",
+        "x",
+        "y",
+        "z"
+      ],
+      "description": "Subject Headings",
+      "subFieldDelimiter": [
+        {
+          "value": "--",
+          "subfields": [
+            "a",
+            "e",
+            "g",
+            "v",
+            "x",
+            "y",
+            "z"
+          ]
+        }
+      ],
+      "applyRulesOnConcatenatedData": true
+    }
+  ],
+  "655": [
+    {
+      "rules": [
+        {
+          "conditions": [
+            {
+              "type": "trim_period, trim"
+            }
+          ]
+        }
+      ],
+      "target": "subjects",
+      "subfield": [
+        "a",
+        "b",
+        "c",
+        "v",
+        "x",
+        "y",
+        "z"
+      ],
+      "description": "Subject Headings",
+      "subFieldDelimiter": [
+        {
+          "value": "--",
+          "subfields": [
+            "a",
+            "e",
+            "g",
+            "v",
+            "x",
+            "y",
+            "z"
+          ]
+        }
+      ],
+      "applyRulesOnConcatenatedData": true
+    }
+  ],
+  "700": [
+    {
+      "entity": [
+        {
+          "target": "contributors.authorityId",
+          "subfield": [
+            "9"
+          ],
+          "description": "Authority ID that controlling the contributor",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_contributor_name_type_id",
+                  "parameter": {
+                    "name": "Personal name"
+                  }
+                }
+              ]
+            }
+          ],
+          "target": "contributors.contributorNameTypeId",
+          "subfield": [],
+          "description": "Type for Personal Name",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_contributor_type_id"
+                }
+              ]
+            }
+          ],
+          "target": "contributors.contributorTypeId",
+          "subfield": [
+            "4"
+          ],
+          "description": "Type of contributor",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_contributor_type_text"
+                }
+              ]
+            }
+          ],
+          "target": "contributors.contributorTypeText",
+          "subfield": [
+            "e"
+          ],
+          "description": "Contributor type free text",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "value": "false",
+              "conditions": []
+            }
+          ],
+          "target": "contributors.primary",
+          "subfield": [],
+          "description": "Primary contributor",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period, trim"
+                }
+              ]
+            }
+          ],
+          "target": "contributors.name",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "f",
+            "g",
+            "j",
+            "k",
+            "l",
+            "n",
+            "p",
+            "q",
+            "t",
+            "u"
+          ],
+          "description": "Personal Name",
+          "applyRulesOnConcatenatedData": true
+        }
+      ]
+    }
+  ],
+  "710": [
+    {
+      "entity": [
+        {
+          "target": "contributors.authorityId",
+          "subfield": [
+            "9"
+          ],
+          "description": "Authority ID that controlling the contributor",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_contributor_name_type_id",
+                  "parameter": {
+                    "name": "Corporate name"
+                  }
+                }
+              ]
+            }
+          ],
+          "target": "contributors.contributorNameTypeId",
+          "subfield": [],
+          "description": "Type for Corporate Name",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_contributor_type_id"
+                }
+              ]
+            }
+          ],
+          "target": "contributors.contributorTypeId",
+          "subfield": [
+            "4"
+          ],
+          "description": "Type of contributor",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_contributor_type_text"
+                }
+              ]
+            }
+          ],
+          "target": "contributors.contributorTypeText",
+          "subfield": [
+            "e"
+          ],
+          "description": "Contributor type free text",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "value": "false",
+              "conditions": []
+            }
+          ],
+          "target": "contributors.primary",
+          "subfield": [],
+          "description": "Primary contributor",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period, trim"
+                }
+              ]
+            }
+          ],
+          "target": "contributors.name",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "f",
+            "g",
+            "k",
+            "l",
+            "n",
+            "p",
+            "t",
+            "u"
+          ],
+          "description": "Corporate Name",
+          "applyRulesOnConcatenatedData": true
+        }
+      ]
+    }
+  ],
+  "711": [
+    {
+      "entity": [
+        {
+          "target": "contributors.authorityId",
+          "subfield": [
+            "9"
+          ],
+          "description": "Authority ID that controlling the contributor",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_contributor_name_type_id",
+                  "parameter": {
+                    "name": "Meeting name"
+                  }
+                }
+              ]
+            }
+          ],
+          "target": "contributors.contributorNameTypeId",
+          "subfield": [],
+          "description": "Type for Meeting Name",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_contributor_type_id"
+                }
+              ]
+            }
+          ],
+          "target": "contributors.contributorTypeId",
+          "subfield": [
+            "4"
+          ],
+          "description": "Type of contributor",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_contributor_type_text"
+                }
+              ]
+            }
+          ],
+          "target": "contributors.contributorTypeText",
+          "subfield": [
+            "j"
+          ],
+          "description": "Contributor type free text",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "value": "false",
+              "conditions": []
+            }
+          ],
+          "target": "contributors.primary",
+          "subfield": [],
+          "description": "Primary contributor",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period, trim"
+                }
+              ]
+            }
+          ],
+          "target": "contributors.name",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "f",
+            "g",
+            "k",
+            "l",
+            "n",
+            "p",
+            "t",
+            "u"
+          ],
+          "description": "Meeting Name",
+          "applyRulesOnConcatenatedData": true
+        }
+      ]
+    }
+  ],
+  "780": [
+    {
+      "entity": [
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim"
+                }
+              ]
+            }
+          ],
+          "target": "precedingTitles.title",
+          "subfield": [
+            "t"
+          ],
+          "description": "The primary title (or label) associated with the resource",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_identifier_type_id_by_name",
+                  "parameter": {
+                    "name": "ISBN"
+                  }
+                }
+              ]
+            }
+          ],
+          "target": "precedingTitles.isbnId",
+          "subfield": [
+            "z"
+          ],
+          "description": "Type for Valid ISBN",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim"
+                }
+              ]
+            }
+          ],
+          "target": "precedingTitles.isbnValue",
+          "subfield": [
+            "z"
+          ],
+          "description": "Value for Valid ISBN",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_identifier_type_id_by_name",
+                  "parameter": {
+                    "name": "ISSN"
+                  }
+                }
+              ]
+            }
+          ],
+          "target": "precedingTitles.issnId",
+          "subfield": [
+            "x"
+          ],
+          "description": "Type for Valid ISSN",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim"
+                }
+              ]
+            }
+          ],
+          "target": "precedingTitles.issnValue",
+          "subfield": [
+            "x"
+          ],
+          "description": "Value for Valid ISSN",
+          "applyRulesOnConcatenatedData": true
+        }
+      ]
+    }
+  ],
+  "785": [
+    {
+      "entity": [
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim"
+                }
+              ]
+            }
+          ],
+          "target": "succeedingTitles.title",
+          "subfield": [
+            "t"
+          ],
+          "description": "The primary title (or label) associated with the resource",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_identifier_type_id_by_name",
+                  "parameter": {
+                    "name": "ISBN"
+                  }
+                }
+              ]
+            }
+          ],
+          "target": "succeedingTitles.isbnId",
+          "subfield": [
+            "z"
+          ],
+          "description": "Type for Valid ISBN",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim"
+                }
+              ]
+            }
+          ],
+          "target": "succeedingTitles.isbnValue",
+          "subfield": [
+            "z"
+          ],
+          "description": "Value for Valid ISBN",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_identifier_type_id_by_name",
+                  "parameter": {
+                    "name": "ISSN"
+                  }
+                }
+              ]
+            }
+          ],
+          "target": "succeedingTitles.issnId",
+          "subfield": [
+            "x"
+          ],
+          "description": "Type for Valid ISSN",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim"
+                }
+              ]
+            }
+          ],
+          "target": "succeedingTitles.issnValue",
+          "subfield": [
+            "x"
+          ],
+          "description": "Value for Valid ISSN",
+          "applyRulesOnConcatenatedData": true
+        }
+      ]
+    }
+  ],
+  "795": [
+    {
+      "entity": [
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Collection name"
+                  }
+                }
+              ]
+            }
+          ],
+          "target": "notes.instanceNoteTypeId",
+          "subfield": [
+            "a",
+            "p"
+          ],
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period"
+                }
+              ]
+            }
+          ],
+          "target": "notes.note",
+          "subfield": [
+            "a",
+            "p"
+          ],
+          "description": "Collection name",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "value": "false",
+              "conditions": []
+            }
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a",
+            "p"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
+        }
+      ]
+    }
+  ],
+  "800": [
+    {
+      "rules": [
+        {
+          "conditions": [
+            {
+              "type": "remove_ending_punc, trim"
+            }
+          ]
+        }
+      ],
+      "target": "series",
+      "subfield": [
+        "a",
+        "b",
+        "c",
+        "d",
+        "e",
+        "f",
+        "g",
+        "h",
+        "j",
+        "k",
+        "l",
+        "m",
+        "n",
+        "o",
+        "p",
+        "q",
+        "r",
+        "s",
+        "t",
+        "u",
+        "v",
+        "w",
+        "x",
+        "3",
+        "5"
+      ],
+      "description": "Series Statement",
+      "applyRulesOnConcatenatedData": true
+    }
+  ],
+  "810": [
+    {
+      "rules": [
+        {
+          "conditions": [
+            {
+              "type": "remove_ending_punc, trim"
+            }
+          ]
+        }
+      ],
+      "target": "series",
+      "subfield": [
+        "a",
+        "b",
+        "c",
+        "d",
+        "e",
+        "f",
+        "g",
+        "h",
+        "k",
+        "l",
+        "m",
+        "n",
+        "o",
+        "p",
+        "r",
+        "s",
+        "t",
+        "u",
+        "v",
+        "w",
+        "x",
+        "3",
+        "5"
+      ],
+      "description": "Series Statement",
+      "applyRulesOnConcatenatedData": true
+    }
+  ],
+  "811": [
+    {
+      "rules": [
+        {
+          "conditions": [
+            {
+              "type": "remove_ending_punc, trim"
+            }
+          ]
+        }
+      ],
+      "target": "series",
+      "subfield": [
+        "a",
+        "c",
+        "d",
+        "e",
+        "f",
+        "g",
+        "h",
+        "j",
+        "k",
+        "l",
+        "n",
+        "p",
+        "q",
+        "s",
+        "t",
+        "u",
+        "v",
+        "w",
+        "x",
+        "3",
+        "5"
+      ],
+      "description": "Series Statement",
+      "applyRulesOnConcatenatedData": true
+    }
+  ],
+  "830": [
+    {
+      "rules": [
+        {
+          "conditions": [
+            {
+              "type": "remove_ending_punc, trim"
+            }
+          ]
+        }
+      ],
+      "target": "series",
+      "subfield": [
+        "a",
+        "d",
+        "f",
+        "g",
+        "h",
+        "k",
+        "l",
+        "m",
+        "n",
+        "o",
+        "p",
+        "r",
+        "s",
+        "t",
+        "v",
+        "w",
+        "x",
+        "3",
+        "5"
+      ],
+      "description": "Series Statement",
+      "applyRulesOnConcatenatedData": true
+    }
+  ],
+  "856": [
+    {
+      "entity": [
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_electronic_access_relations_id"
+                }
+              ]
+            }
+          ],
+          "target": "electronicAccess.relationshipId",
+          "subfield": [
+            "3",
+            "y",
+            "u",
+            "z"
+          ],
+          "description": "Relationship between the electronic resource at the location identified and the item described in the record as a whole",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "remove_ending_punc, trim"
+                }
+              ]
+            }
+          ],
+          "target": "electronicAccess.uri",
+          "subfield": [
+            "u"
+          ],
+          "description": "URI"
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "remove_ending_punc, trim"
+                }
+              ]
+            }
+          ],
+          "target": "electronicAccess.linkText",
+          "subfield": [
+            "y"
+          ],
+          "description": "Link text"
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "remove_ending_punc, trim"
+                }
+              ]
+            }
+          ],
+          "target": "electronicAccess.materialsSpecification",
+          "subfield": [
+            "3"
+          ],
+          "description": "Materials Specified"
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "remove_ending_punc, trim"
+                }
+              ]
+            }
+          ],
+          "target": "electronicAccess.publicNote",
+          "subfield": [
+            "z"
+          ],
+          "description": "URL public note"
+        }
+      ]
+    }
+  ],
+  "880": [
+    {
+      "target": "",
+      "subfield": [
+        "6"
+      ],
+      "description": "Field for target post-processing based on first 3 digits in subfield 6",
+      "fieldReplacementRule": [
+        {
+          "targetField": "700",
+          "sourceDigits": "100"
+        },
+        {
+          "targetField": "710",
+          "sourceDigits": "110"
+        },
+        {
+          "targetField": "711",
+          "sourceDigits": "111"
+        },
+        {
+          "targetField": "246",
+          "sourceDigits": "245"
+        }
+      ],
+      "fieldReplacementBy3Digits": true
+    }
+  ],
+  "910": [
+    {
+      "rules": [
+        {
+          "conditions": [
+            {
+              "type": "remove_ending_punc, trim"
+            }
+          ]
+        }
+      ],
+      "target": "administrativeNotes",
+      "subfield": [
+        "a"
+      ],
+      "description": "Administrative Note",
+      "applyRulesOnConcatenatedData": true
+    }
+  ],
+  "956": [
+    {
+      "entity": [
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_electronic_access_relations_id"
+                }
+              ]
+            }
+          ],
+          "target": "electronicAccess.relationshipId",
+          "subfield": [
+            "3",
+            "y",
+            "u",
+            "z"
+          ],
+          "description": "Relationship between the electronic resource at the location identified and the item described in the record as a whole",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "remove_ending_punc, trim"
+                }
+              ]
+            }
+          ],
+          "target": "electronicAccess.uri",
+          "subfield": [
+            "u"
+          ],
+          "description": "URI"
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "remove_ending_punc, trim"
+                }
+              ]
+            }
+          ],
+          "target": "electronicAccess.linkText",
+          "subfield": [
+            "y"
+          ],
+          "description": "Link text"
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "remove_ending_punc, trim"
+                }
+              ]
+            }
+          ],
+          "target": "electronicAccess.materialsSpecification",
+          "subfield": [
+            "3"
+          ],
+          "description": "Materials Specified"
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "remove_ending_punc, trim"
+                }
+              ]
+            }
+          ],
+          "target": "electronicAccess.publicNote",
+          "subfield": [
+            "z"
+          ],
+          "description": "URL public note"
         }
       ]
     }

--- a/spec/fixtures/json/data_import/marc_hold_mappings.json
+++ b/spec/fixtures/json/data_import/marc_hold_mappings.json
@@ -456,6 +456,22 @@
             {
               "conditions": [
                 {
+                  "type": "remove_ending_punc, trim"
+                }
+              ]
+            }
+          ],
+          "target": "holdingsStatements.note",
+          "subfield": [
+            "z"
+          ],
+          "description": "Public note"
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
                   "type": "set_call_number_type_id"
                 }
               ]
@@ -477,11 +493,9 @@
           ],
           "target": "permanentLocationId",
           "subfield": [
-            "b",
-            "c"
+            "b"
           ],
-          "description": "The permanent shelving location",
-          "applyRulesOnConcatenatedData": true
+          "description": "The permanent shelving location"
         },
         {
           "target": "callNumber",
@@ -637,7 +651,9 @@
           ],
           "target": "holdingsStatements.statement",
           "subfield": [
-            "a"
+            "a",
+            "v",
+            "y"
           ],
           "description": "Textual description of the holdings"
         },


### PR DESCRIPTION
The marc bib mapping is out of tag order. For some reason, when I pull from folio-test my file is in tag order but loading it back to, say, folio-dev, the mapping is out of tag order. 🤷 In any case, checking in the ordered tag version of the marc bib mapping.

PR also includes legitimate updates to mhld mapping.