### PR TITLE
Adds task to create user custom fields

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -57,6 +57,7 @@ task delete_tenant_settings: %i[tenant:delete_locations
 
 desc 'Load all user settings [groups, waivers, refunds, comments, owners, manual charges, payments, patron block conditions, templates, and limits]'
 task load_user_settings: %i[users:load_user_groups
+                            users:load_user_custom_fields
                             users:load_waivers
                             users:load_refunds
                             users:load_comments

--- a/Rakefile
+++ b/Rakefile
@@ -163,7 +163,7 @@ task load_all_data_import_profiles: %i[data_import:load_job_profiles
                                        data_import:load_mapping_profiles
                                        data_import:load_profile_associations]
 
-desc 'Load all configurations [edge-sip2 BULKEDIT CHECKOUT FAST_ADD LOAN_HISTORY CHECKOUT FAST_ADD INVOICE ORDERS ORG SETTINGS TENANT USERSBL] smtp_config and login'
+desc 'Load all configurations [edge-sip2 BULKEDIT CHECKOUT FAST_ADD LOAN_HISTORY CHECKOUT FAST_ADD INVOICE ORDERS ORG SETTINGS TENANT USERS USERSBL] smtp_config and login'
 task load_all_configurations: %i[configurations:load_configs
                                  configurations:load_email_config
                                  configurations:load_login_configs]

--- a/spec/fixtures/json/users/custom_fields.json
+++ b/spec/fixtures/json/users/custom_fields.json
@@ -1,0 +1,78 @@
+{
+  "customFields": [
+    {
+      "entityType": "user",
+      "helpText": "",
+      "id": null,
+      "name": "Affiliation",
+      "required": false,
+      "type": "TEXTBOX_SHORT",
+      "visible": true
+    },
+    {
+      "entityType": "user",
+      "helpText": "",
+      "id": null,
+      "name": "SecondAffiliation",
+      "required": false,
+      "type": "TEXTBOX_SHORT",
+      "visible": true
+    },
+    {
+      "entityType": "user",
+      "helpText": "",
+      "id": null,
+      "name": "Usergroup",
+      "required": false,
+      "selectField": {
+        "multiSelect": false,
+        "options": {
+          "values": [
+            {
+              "default": false,
+              "id": "opt_1",
+              "value": "Acting Instructor"
+            },
+            {
+              "id": "opt_2",
+              "value": "Clinical Instructor"
+            },
+            {
+              "id": "opt_3",
+              "value": "Consulting Instructor"
+            },
+            {
+              "default": false,
+              "id": "opt_0",
+              "value": "Instructor"
+            },
+            {
+              "id": "opt_4",
+              "value": "Lecturer"
+            }
+          ]
+        }
+      },
+      "type": "SINGLE_SELECT_DROPDOWN",
+      "visible": true
+    },
+    {
+      "entityType": "user",
+      "helpText": "",
+      "id": null,
+      "name": "MobileId",
+      "required": false,
+      "type": "TEXTBOX_SHORT",
+      "visible": true
+    },
+    {
+      "entityType": "user",
+      "helpText": "",
+      "id": null,
+      "name": "ProximityChipId",
+      "required": false,
+      "type": "TEXTBOX_SHORT",
+      "visible": true
+    }
+  ]
+}

--- a/spec/users/load_user_settings_task_spec.rb
+++ b/spec/users/load_user_settings_task_spec.rb
@@ -5,6 +5,7 @@ require 'spec_helper'
 
 describe 'user settings rake tasks' do
   let(:load_user_groups_task) { Rake.application.invoke_task 'users:load_user_groups' }
+  let(:load_user_custom_fields_task) { Rake.application.invoke_task 'users:load_user_custom_fields' }
   # let(:load_address_types_task) { Rake.application.invoke_task 'users:load_address_types' }
   let(:load_waivers_task) { Rake.application.invoke_task 'users:load_waivers' }
   let(:load_payments_task) { Rake.application.invoke_task 'users:load_payments' }
@@ -22,6 +23,7 @@ describe 'user settings rake tasks' do
       .with(body: Settings.okapi.login_params.to_h)
 
     stub_request(:post, 'http://example.com/groups')
+    stub_request(:put, 'http://example.com/custom-fields')
     stub_request(:post, 'http://example.com/addresstypes')
     stub_request(:post, 'http://example.com/waives')
     stub_request(:post, 'http://example.com/payments')
@@ -53,6 +55,14 @@ describe 'user settings rake tasks' do
   #     expect(address_types_json['addressTypes'].sample).to match_json_schema('mod-users', 'addresstype')
   #   end
   # end
+
+  context 'when creating user custom fields' do
+    let(:custom_fields_json) { UsersTaskHelpers.custom_fields_json }
+
+    it 'has 5 custom fields' do
+      expect(custom_fields_json['customFields'].length).to eq 5
+    end
+  end
 
   context 'when creating waivers' do
     let(:waivers_json) { load_waivers_task.send(:waivers_json) }

--- a/tasks/helpers/users.rb
+++ b/tasks/helpers/users.rb
@@ -15,6 +15,14 @@ module UsersTaskHelpers
     @@folio_request.post('/groups', obj.to_json)
   end
 
+  def custom_fields_json
+    JSON.parse(File.read("#{Settings.json}/users/custom_fields.json"))
+  end
+
+  def custom_fields_put(obj)
+    @@folio_request.put('/custom-fields', obj.to_json)
+  end
+
   def address_types_json
     JSON.parse(File.read("#{Settings.json}/users/addresstypes.json"))
   end

--- a/tasks/users/load_user_settings.rake
+++ b/tasks/users/load_user_settings.rake
@@ -13,6 +13,11 @@ namespace :users do
     end
   end
 
+  desc 'load user custom fields into folio'
+  task :load_user_custom_fields do
+    custom_fields_put(custom_fields_json)
+  end
+
   # Using instead the default reference data address types
   # desc 'load address types into folio'
   # task :load_address_types do


### PR DESCRIPTION
Closes #137 
N.B. the POST to `/configurations/entries` will be done in the step `rake load_all_configurations`. The value `USERS` needs to be added to all config/settings yaml files.
Also, there is not a schema to validate against so the test just checks the number of custom fields in the json. 🤷 
Also also, see the issue comment about the PUT taking a long time but it did eventually complete.