### PR TITLE
Add department uuids based on privgroups

### DIFF
--- a/bin/folio_user.rb
+++ b/bin/folio_user.rb
@@ -13,8 +13,10 @@ user_json = xml_user_result.to_json
 
 folio_response = folio.post('/user-import', user_json)
 
+# folio-user.log file used for loading users into illiad.
 puts user_json
 
+# File used for emailing the user import result
 File.open('log/user-import-response.log', 'a') do |f|
   log_json = {
     'batch_number' => ARGV[1],

--- a/bin/folio_user.rb
+++ b/bin/folio_user.rb
@@ -11,7 +11,7 @@ xml_user_result.process_xml_lines(ARGV[0])
 
 user_json = xml_user_result.to_json
 
-folio_response = folio.post('/user-import', user_json, no_response: true)
+folio_response = folio.post('/user-import', user_json)
 
 puts user_json
 

--- a/lib/modules/xml_user_helpers.rb
+++ b/lib/modules/xml_user_helpers.rb
@@ -136,10 +136,10 @@ module XmlUserHelpers
 
   def add_departments
     @person_hash['departments'] = []
-    # Add the department UUID for SUL by default
-    @person_hash['departments'] << 'e88216c6-b39e-477e-a094-de10b941837d'
+    # Add the default SUL department
+    @person_hash['departments'] << 'Stanford Libraries (SUL)'
     @priv_groups.select do |p|
-      p.include?('organization:gsb') && @person_hash['departments'] << '90a61554-e4e5-476d-bd64-141822c4221f'
+      p.include?('organization:gsb') && @person_hash['departments'] << 'Graduate School of Business (GSB)'
     end
   end
 

--- a/lib/modules/xml_user_helpers.rb
+++ b/lib/modules/xml_user_helpers.rb
@@ -134,6 +134,15 @@ module XmlUserHelpers
   #   @priv_groups.select { |p| p.include?('folio:') && @person_hash['customFields']['workgroup'] = p }
   # end
 
+  def add_departments
+    @person_hash['departments'] = []
+    # Add the department UUID for SUL by default
+    @person_hash['departments'] << 'e88216c6-b39e-477e-a094-de10b941837d'
+    @priv_groups.select do |p|
+      p.include?('organization:gsb') && @person_hash['departments'] << '90a61554-e4e5-476d-bd64-141822c4221f'
+    end
+  end
+
   def to_json(*)
     @hash.to_json
   end

--- a/lib/xml_user.rb
+++ b/lib/xml_user.rb
@@ -53,6 +53,7 @@ class XmlUser
       home_phone(Nokogiri::XML(xmlline).xpath('//Person/telephone[@type="permanent"]'))
       address(Nokogiri::XML(xmlline).xpath('//Person/place'))
       affiliation(affiliation_nodes)
+      add_departments
       add_user_to_hash
     end
   end

--- a/spec/users/xml_user_spec.rb
+++ b/spec/users/xml_user_spec.rb
@@ -73,6 +73,10 @@ RSpec.describe XmlUser do
       #   expect(JSON.parse(result.to_json)['users'][0]['customFields']['workgroup']).to eq 'folio:circ-staff'
       # end
 
+      it 'has the department field with the default value' do
+        expect(JSON.parse(result.to_json)['users'][0]['departments'].length).to be_positive
+      end
+
       it 'has the correct patron group' do
         expect(JSON.parse(result.to_json)['users'][0]['patronGroup']).to eq 'staff'
       end

--- a/tasks/helpers/illiad.rb
+++ b/tasks/helpers/illiad.rb
@@ -39,8 +39,4 @@ module IlliadTaskHelpers
 
     'STF'
   end
-
-  def illiad_response(response, user)
-    puts "Got response #{response} for #{user}"
-  end
 end

--- a/tasks/helpers/illiad.rb
+++ b/tasks/helpers/illiad.rb
@@ -35,7 +35,7 @@ module IlliadTaskHelpers
   end
 
   def user_department(user)
-    user['department'].include?('90a61554-e4e5-476d-bd64-141822c4221f') && 'S7Z'
+    user['department']&.include?('90a61554-e4e5-476d-bd64-141822c4221f') && 'S7Z'
 
     'STF'
   end

--- a/tasks/helpers/illiad.rb
+++ b/tasks/helpers/illiad.rb
@@ -23,7 +23,7 @@ module IlliadTaskHelpers
       Phone: user['personal']['phone'],
       ExpirationDate: user['expirationDate'],
       UserInfo1: user['externalSystemId'],
-      NVTGC: 'STF',
+      NVTGC: user_department(user),
       NotificationMethod: 'Electronic',
       DeliveryMethod: 'Hold for Pickup',
       AuthorizedUsers: 'SUL',
@@ -32,6 +32,12 @@ module IlliadTaskHelpers
       Organization: 'SUL',
       LastChangedDate: DateTime.now.strftime('%Y-%m-%d %H:%M:%S')
     }.to_json
+  end
+
+  def user_department(user)
+    user['department'].include?('90a61554-e4e5-476d-bd64-141822c4221f') && 'S7Z'
+
+    'STF'
   end
 
   def illiad_response(response, user)

--- a/tasks/users/load_illiad_users.rake
+++ b/tasks/users/load_illiad_users.rake
@@ -10,9 +10,9 @@ namespace :illiad do
   task :fetch_and_load_users, [:date] do |_, args|
     folio_json_users(args[:date]).each do |user|
       JSON.parse(user)['users'].each do |folio_user|
-        illiad_user = illiad_user(folio_user)
+        ill_user = illiad_user(folio_user)
         illiad_response(
-          IlliadRequest.new.post('ILLiadWebPlatform/Users', illiad_user), illiad_user
+          IlliadRequest.new.post('ILLiadWebPlatform/Users', ill_user), ill_user
         )
       end
     end

--- a/tasks/users/load_illiad_users.rake
+++ b/tasks/users/load_illiad_users.rake
@@ -10,8 +10,9 @@ namespace :illiad do
   task :fetch_and_load_users, [:date] do |_, args|
     folio_json_users(args[:date]).each do |user|
       JSON.parse(user)['users'].each do |folio_user|
+        illiad_user = illiad_user(folio_user)
         illiad_response(
-          IlliadRequest.new.post('ILLiadWebPlatform/Users', illiad_user(folio_user)), illiad_user(folio_user)
+          IlliadRequest.new.post('ILLiadWebPlatform/Users', illiad_user), illiad_user
         )
       end
     end

--- a/tasks/users/load_illiad_users.rake
+++ b/tasks/users/load_illiad_users.rake
@@ -12,7 +12,7 @@ namespace :illiad do
       # skip unparseable log lines
       begin
         JSON.parse(user)
-      rescue JSON::ParserError => e
+      rescue JSON::ParserError
         next
       end
 

--- a/tasks/users/load_illiad_users.rake
+++ b/tasks/users/load_illiad_users.rake
@@ -9,6 +9,13 @@ namespace :illiad do
   desc 'fetch and load illiad users from folio'
   task :fetch_and_load_users, [:date] do |_, args|
     folio_json_users(args[:date]).each do |user|
+      # skip unparseable log lines
+      begin
+        JSON.parse(user)
+      rescue JSON::ParserError => e
+        next
+      end
+
       JSON.parse(user)['users'].each do |folio_user|
         ill_user = illiad_user(folio_user)
         puts IlliadRequest.new.post('ILLiadWebPlatform/Users', ill_user), ill_user

--- a/tasks/users/load_illiad_users.rake
+++ b/tasks/users/load_illiad_users.rake
@@ -11,9 +11,7 @@ namespace :illiad do
     folio_json_users(args[:date]).each do |user|
       JSON.parse(user)['users'].each do |folio_user|
         ill_user = illiad_user(folio_user)
-        illiad_response(
-          IlliadRequest.new.post('ILLiadWebPlatform/Users', ill_user), ill_user
-        )
+        puts IlliadRequest.new.post('ILLiadWebPlatform/Users', ill_user), ill_user
       end
     end
   end


### PR DESCRIPTION
I created two depatments in FOLIO prod:
```
{
  "departments": [
    {
      "id": "90a61554-e4e5-476d-bd64-141822c4221f",
      "name": "Graduate School of Business (GSB)",
      "code": "S7Z",
      "usageNumber": 0,
      "metadata": {
        "createdDate": "2023-09-15T19:01:09.317+00:00",
        "createdByUserId": "84109a43-8ad2-482e-bb8e-b0675f57461c",
        "updatedDate": "2023-09-15T19:01:09.317+00:00",
        "updatedByUserId": "84109a43-8ad2-482e-bb8e-b0675f57461c"
      }
    },
    {
      "id": "e88216c6-b39e-477e-a094-de10b941837d",
      "name": "Stanford Libraries (SUL)",
      "code": "STF",
      "usageNumber": 0,
      "metadata": {
        "createdDate": "2023-09-15T19:00:53.155+00:00",
        "createdByUserId": "84109a43-8ad2-482e-bb8e-b0675f57461c",
        "updatedDate": "2023-09-15T19:00:53.155+00:00",
        "updatedByUserId": "84109a43-8ad2-482e-bb8e-b0675f57461c"
      }
    }
  ],
  "totalRecords": 2
}
```
