### PR TITLE
Use department name not uuid

### DIFF
--- a/tasks/helpers/illiad.rb
+++ b/tasks/helpers/illiad.rb
@@ -35,7 +35,7 @@ module IlliadTaskHelpers
   end
 
   def user_department(user)
-    user['department']&.include?('90a61554-e4e5-476d-bd64-141822c4221f') && 'S7Z'
+    user['department']&.include?('Graduate School of Business (GSB)') && 'S7Z'
 
     'STF'
   end


### PR DESCRIPTION
The api doc is incorrect here: https://s3.amazonaws.com/foliodocs/api/mod-user-import/p/import.html#user_import_post

It takes department names, not uuids.