### PR TITLE
Updates tasks for index settings and reindexing

### DIFF
--- a/tasks/inventory/elasticsearch_indexing.rake
+++ b/tasks/inventory/elasticsearch_indexing.rake
@@ -4,8 +4,7 @@ namespace :inventory do
   desc 'recreate search index (drops existing indices) for [instance, authority]'
   task :recreate_search_index, [:resource_name] do |_, args|
     FolioRequest.new.post('/search/index/inventory/reindex',
-                          '{ "recreateIndex": "true", "resourceName": "'"#{args[:resource_name]}"'",
-                             "indexSettings": { "numberOfReplicas": 0, "refreshInterval": 120 } }')
+                          '{ "recreateIndex": "true", "resourceName": "'"#{args[:resource_name]}"'" }')
   end
 
   desc 'reindex search index for [instance, authority]'
@@ -17,13 +16,6 @@ namespace :inventory do
   desc 'monitor instances published to Kafka for reindex with given job id'
   task :search_index_job_status, [:job_id] do |_, args|
     FolioRequest.new.get("/instance-storage/reindex/#{args[:job_id]}")
-  end
-
-  desc 'update index dynamic settings to optimize full reindex fo [instance, authority]'
-  task :optimize_index_settings, [:resource_name] do |_, args|
-    FolioRequest.new.put('/search/index/settings',
-                         '{ "resourceName": "'"#{args[:resource_name]}"'",
-                            "indexSettings": { "numberOfReplicas": 0, "refreshInterval": -1 } }')
   end
 
   desc 'update index dynamic settings to defaults (2 replicas) for [instance, authority]'

--- a/tasks/inventory/elasticsearch_indexing.rake
+++ b/tasks/inventory/elasticsearch_indexing.rake
@@ -1,18 +1,35 @@
 # frozen_string_literal: true
 
 namespace :inventory do
-  desc 'recreate search index from scratch'
-  task :recreate_search_index do
-    FolioRequest.new.post('/search/index/inventory/reindex', '{ "recreateIndex": "true" }')
+  desc 'recreate search index (drops existing indices) with given resource name [instance, authority]'
+  task :recreate_search_index, [:resource_name] do |_, args|
+    FolioRequest.new.post('/search/index/inventory/reindex',
+                          '{ "recreateIndex": "true", "resourceName": "'"#{args[:resource_name]}"'",
+                             "indexSettings": { "numberOfReplicas": 0, "refreshInterval": 120 } }')
   end
 
-  desc 'reindex search'
-  task :reindex_search do
-    FolioRequest.new.post_no_body('/search/index/inventory/reindex')
+  desc 'reindex search index with given resource name [instance, authority]'
+  task :reindex_search, [:resource_name] do |_, args|
+    FolioRequest.new.post('/search/index/inventory/reindex',
+                          '{ "resourceName": "'"#{args[:resource_name]}"'" }')
   end
 
-  desc 'monitor a search reindex job with given id'
+  desc 'monitor instances published to Kafka for reindex with given job id'
   task :search_index_job_status, [:job_id] do |_, args|
     FolioRequest.new.get("/instance-storage/reindex/#{args[:job_id]}")
+  end
+
+  desc 'update index dynamic settings to optimize full reindex with given resource name [instance, authority]'
+  task :optimize_index_settings, [:resource_name] do |_, args|
+    FolioRequest.new.put('/search/index/settings',
+                         '{ "resourceName": "'"#{args[:resource_name]}"'",
+                            "indexSettings": { "numberOfReplicas": 0, "refreshInterval": -1 } }')
+  end
+
+  desc 'update index dynamic settings to defaults (2 replicas) with given resource name [instance, authority]'
+  task :default_index_settings, [:resource_name] do |_, args|
+    FolioRequest.new.put('/search/index/settings',
+                         '{ "resourceName": "'"#{args[:resource_name]}"'",
+                            "indexSettings": { "numberOfReplicas": 2, "refreshInterval": 1 } }')
   end
 end

--- a/tasks/inventory/elasticsearch_indexing.rake
+++ b/tasks/inventory/elasticsearch_indexing.rake
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
 namespace :inventory do
-  desc 'recreate search index (drops existing indices) with given resource name [instance, authority]'
+  desc 'recreate search index (drops existing indices) for [instance, authority]'
   task :recreate_search_index, [:resource_name] do |_, args|
     FolioRequest.new.post('/search/index/inventory/reindex',
                           '{ "recreateIndex": "true", "resourceName": "'"#{args[:resource_name]}"'",
                              "indexSettings": { "numberOfReplicas": 0, "refreshInterval": 120 } }')
   end
 
-  desc 'reindex search index with given resource name [instance, authority]'
+  desc 'reindex search index for [instance, authority]'
   task :reindex_search, [:resource_name] do |_, args|
     FolioRequest.new.post('/search/index/inventory/reindex',
                           '{ "resourceName": "'"#{args[:resource_name]}"'" }')
@@ -19,14 +19,14 @@ namespace :inventory do
     FolioRequest.new.get("/instance-storage/reindex/#{args[:job_id]}")
   end
 
-  desc 'update index dynamic settings to optimize full reindex with given resource name [instance, authority]'
+  desc 'update index dynamic settings to optimize full reindex fo [instance, authority]'
   task :optimize_index_settings, [:resource_name] do |_, args|
     FolioRequest.new.put('/search/index/settings',
                          '{ "resourceName": "'"#{args[:resource_name]}"'",
                             "indexSettings": { "numberOfReplicas": 0, "refreshInterval": -1 } }')
   end
 
-  desc 'update index dynamic settings to defaults (2 replicas) with given resource name [instance, authority]'
+  desc 'update index dynamic settings to defaults (2 replicas) for [instance, authority]'
   task :default_index_settings, [:resource_name] do |_, args|
     FolioRequest.new.put('/search/index/settings',
                          '{ "resourceName": "'"#{args[:resource_name]}"'",

--- a/tasks/inventory/elasticsearch_indexing.rake
+++ b/tasks/inventory/elasticsearch_indexing.rake
@@ -19,7 +19,7 @@ namespace :inventory do
   end
 
   desc 'update index dynamic settings to defaults (2 replicas) for [instance, authority]'
-  task :default_index_settings, [:resource_name] do |_, args|
+  task :default_search_index_settings, [:resource_name] do |_, args|
     FolioRequest.new.put('/search/index/settings',
                          '{ "resourceName": "'"#{args[:resource_name]}"'",
                             "indexSettings": { "numberOfReplicas": 2, "refreshInterval": 1 } }')


### PR DESCRIPTION
Closes #280

~Including indexSettings in a POST to `/search/index/inventory/reindex` and the PUT to `/search/index/settings` aren't available yet in our version of mod-search.~

Reviewed the [Data Indexing section](https://github.com/folio-org/mod-search?tab=readme-ov-file#recreating-elasticsearch-index) of the mod-search README revealed we should pass resourceName "instance" or "authority" to tell which indices we want reindexed or re-created. Also reviewed the [Search API docs](https://s3.amazonaws.com/foliodocs/api/mod-search/s/mod-search.html#tag/index-management/operation/updateIndexDynamicSettings) for updating index dynamic settings. Added tasks to update index dynamic settings for each resource indices (instance or authority).