### PR TITLE
Adds task and test for deleting a specific module config.

### DIFF
--- a/spec/configurations/delete_configs_task_spec.rb
+++ b/spec/configurations/delete_configs_task_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rake'
+require 'spec_helper'
+
+describe 'delete module config rake task' do
+  let(:delete_module_configs_task) { Rake.application.invoke_task 'configurations:delete_module_configs[LOGIN-SAML]' }
+
+  before do
+    stub_request(:post, 'http://example.com/authn/login')
+      .with(body: Settings.okapi.login_params.to_h)
+
+    stub_request(:get, 'http://example.com/configurations/entries?limit=50')
+      .with(query: { query: 'module==LOGIN-SAML' })
+      .to_return(body: '{ "configs": [{"id": "saml-123"}, {"id": "saml-456"}] }')
+
+    stub_request(:delete, %r{.*configurations/entries/saml.*})
+
+    delete_module_configs_task
+  end
+
+  it 'deletes configs for a specified module' do
+    expect(WebMock).to have_requested(:delete, 'http://example.com/configurations/entries/saml-456').once
+  end
+end

--- a/tasks/configurations/delete_config_entries.rake
+++ b/tasks/configurations/delete_config_entries.rake
@@ -14,6 +14,15 @@ namespace :configurations do
     end
   end
 
+  desc 'delete config for specified module (see app config for list)'
+  task :delete_module_configs, [:module] do |_, args|
+    config_data = config_entry_get(args[:module])
+    config_ids = config_entry_ids(config_data)
+    config_ids.each do |id|
+      config_entry_delete(id)
+    end
+  end
+
   desc 'delete tenant addresses from folio'
   task :delete_tenant_addresses do
     ids = Uuids.tenant_addresses.values

--- a/tasks/helpers/configurations.rb
+++ b/tasks/helpers/configurations.rb
@@ -47,6 +47,19 @@ module ConfigurationsTaskHelpers
     entry
   end
 
+  def config_entry_ids(hash)
+    ids = []
+    hash['configs'].each do |obj|
+      ids.push(obj['id'])
+    end
+    ids
+  end
+
+  def config_entry_get(module_code)
+    hash = @@folio_request.get("/configurations/entries?query=module==#{module_code}&limit=50")
+    trim_hash(hash, 'configs')
+  end
+
   def config_entry_post(hash)
     @@folio_request.post('/configurations/entries', hash.to_json)
   end


### PR DESCRIPTION
Closes #272 

You can test it in folio dev by doing:
- `rake configurations:pull_module_configs[CHECKOUT]`
- `rake configurations:delete_module_configs[CHECKOUT]`
- go to Settings > Developer > Okapi config entries and see that checkout is no longer there
- `rake configurations:load_module_configs[CHECKOUT]`