### PR TITLE
Use authenticated requests on the cluster

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -30,7 +30,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         push: true
-        tags: ghcr.io/sul-dlss/folio-tasks
+        tags: ghcr.io/sul-dlss/folio-tasks:${{ steps.extract_branch.outputs.branch }}
         file: Dockerfile
 
   tests:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -30,7 +30,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         push: true
-        tags: ghcr.io/sul-dlss/folio-tasks:${{ steps.extract_branch.outputs.branch }}
+        tags: ghcr.io/sul-dlss/folio-tasks
         file: Dockerfile
 
   tests:

--- a/config/settings/pod.yml
+++ b/config/settings/pod.yml
@@ -1,11 +1,7 @@
 okapi:
   url: htts://okapi:9130
   headers:
-    X-Okapi-Tenant: sul
     User-Agent: FolioApiClient
-  login_params:
-    username: user
-    password: pass
 
 hostname: https://folio.stanford.edu
 namespace: folio

--- a/lib/folio_request.rb
+++ b/lib/folio_request.rb
@@ -75,12 +75,6 @@ class FolioRequest
       .request(method, base_url + path, **other)
   end
 
-  def unauthenticated_request(path, headers: {}, method: :get, **other)
-    HTTP
-      .headers(DEFAULT_HEADERS.merge(headers))
-      .request(method, base_url + path, **other)
-  end
-
   def base_url
     Settings.okapi.url
   end

--- a/tasks/helpers/okapi.rb
+++ b/tasks/helpers/okapi.rb
@@ -7,11 +7,11 @@ module OkapiTaskHelpers
   include FolioRequestHelper
 
   def timers_get
-    JSON.parse(@@folio_request.authenticated_request('/_/proxy/tenants/sul/timers'))
+    JSON.parse(@@folio_request.request('/_/proxy/tenants/sul/timers'))
   end
 
   def timers_patch(json)
-    response = @@folio_request.authenticated_request('/_/proxy/tenants/sul/timers', method: :patch, body: json)
+    response = @@folio_request.request('/_/proxy/tenants/sul/timers', method: :patch, body: json)
     response.code
   end
 

--- a/tasks/helpers/okapi.rb
+++ b/tasks/helpers/okapi.rb
@@ -7,11 +7,11 @@ module OkapiTaskHelpers
   include FolioRequestHelper
 
   def timers_get
-    JSON.parse(@@folio_request.unauthenticated_request('/_/proxy/tenants/sul/timers'))
+    JSON.parse(@@folio_request.authenticated_request('/_/proxy/tenants/sul/timers'))
   end
 
   def timers_patch(json)
-    response = @@folio_request.unauthenticated_request('/_/proxy/tenants/sul/timers', method: :patch, body: json)
+    response = @@folio_request.authenticated_request('/_/proxy/tenants/sul/timers', method: :patch, body: json)
     response.code
   end
 


### PR DESCRIPTION
One last small PR. When run on the cluster we need to use authenticated requests.